### PR TITLE
Update authz environment variables with OIDC subjects for other services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
-
-
-
 provider "aws" {
   region = var.aws_region
 }
+
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
 
 module "vpc" {
   source     = "./modules/vpc"
@@ -73,6 +74,8 @@ module "control_plane" {
   stage     = var.stage
 
   aws_region                          = var.aws_region
+  aws_account_id                      = data.aws_caller_identity.current.account_id
+  aws_partition                       = data.aws_partition.current.id
   database_secret_sm_arn              = module.control_plane_db.secret_arn
   database_security_group_id          = module.control_plane_db.security_group_id
   eventbus_arn                        = module.events.event_bus_arn

--- a/main.tf
+++ b/main.tf
@@ -146,21 +146,23 @@ module "access_handler" {
 }
 
 module "authz" {
-  source                   = "./modules/authz"
-  namespace                = var.namespace
-  stage                    = var.stage
-  aws_region               = var.aws_region
-  eventbus_arn             = module.events.event_bus_arn
-  release_tag              = var.release_tag
-  subnet_ids               = module.vpc.private_subnet_ids
-  vpc_id                   = module.vpc.vpc_id
-  ecs_cluster_id           = module.ecs.cluster_id
-  alb_listener_arn         = module.alb.listener_arn
-  dynamodb_table_name      = module.authz_db.dynamodb_table_name
-  enable_verbose_logging   = var.enable_verbose_logging
-  dynamodb_table_arn       = module.authz_db.dynamodb_table_arn
-  app_url                  = var.app_url
-  oidc_terraform_client_id = module.cognito.terraform_client_id
-  oidc_trusted_issuer      = module.cognito.auth_issuer
+  source                                = "./modules/authz"
+  namespace                             = var.namespace
+  stage                                 = var.stage
+  aws_region                            = var.aws_region
+  eventbus_arn                          = module.events.event_bus_arn
+  release_tag                           = var.release_tag
+  subnet_ids                            = module.vpc.private_subnet_ids
+  vpc_id                                = module.vpc.vpc_id
+  ecs_cluster_id                        = module.ecs.cluster_id
+  alb_listener_arn                      = module.alb.listener_arn
+  dynamodb_table_name                   = module.authz_db.dynamodb_table_name
+  enable_verbose_logging                = var.enable_verbose_logging
+  dynamodb_table_arn                    = module.authz_db.dynamodb_table_arn
+  app_url                               = var.app_url
+  oidc_trusted_issuer                   = module.cognito.auth_issuer
+  oidc_terraform_client_id              = module.cognito.terraform_client_id
+  oidc_access_handler_service_client_id = module.cognito.access_handler_service_client_id
+  oidc_control_plane_client_id          = module.cognito.control_plane_service_client_id
 }
 

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -162,8 +162,15 @@ resource "aws_ecs_task_definition" "authz_task" {
       {
         name  = "CF_OIDC_TERRAFORM_CLIENT_ID",
         value = var.oidc_terraform_client_id
+      },
+      {
+        name  = "CF_OIDC_CONTROL_PLANE_SERVICE_CLIENT_ID",
+        value = var.oidc_control_plane_client_id
+      },
+      {
+        name  = "CF_OIDC_ACCESS_SERVICE_CLIENT_ID",
+        value = var.oidc_access_handler_service_client_id
       }
-
     ],
     secrets = []
 

--- a/modules/authz/variables.tf
+++ b/modules/authz/variables.tf
@@ -102,3 +102,13 @@ variable "oidc_terraform_client_id" {
   description = "Terraform Service Account OIDC Client ID"
   type        = string
 }
+
+variable "oidc_control_plane_client_id" {
+  description = "Control Plane Service Account OIDC Client ID"
+  type        = string
+}
+
+variable "oidc_access_handler_service_client_id" {
+  description = "Access Handler Service Account OIDC Client ID"
+  type        = string
+}

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -213,3 +213,20 @@ resource "aws_cognito_user_pool_client" "control_plane_service_client" {
   allowed_oauth_flows_user_pool_client = true
   generate_secret                      = true
 }
+
+
+resource "aws_cognito_user_pool_client" "acces_handler_service_client" {
+  name         = "${var.namespace}-${var.stage}-access-handler-client"
+  user_pool_id = aws_cognito_user_pool.cognito_user_pool.id
+
+  explicit_auth_flows = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH"
+  ]
+
+  access_token_validity                = 8
+  allowed_oauth_flows                  = ["client_credentials"]
+  allowed_oauth_scopes                 = aws_cognito_resource_server.resource_server.scope_identifiers
+  allowed_oauth_flows_user_pool_client = true
+  generate_secret                      = true
+}

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -215,7 +215,7 @@ resource "aws_cognito_user_pool_client" "control_plane_service_client" {
 }
 
 
-resource "aws_cognito_user_pool_client" "acces_handler_service_client" {
+resource "aws_cognito_user_pool_client" "access_handler_service_client" {
   name         = "${var.namespace}-${var.stage}-access-handler-client"
   user_pool_id = aws_cognito_user_pool.cognito_user_pool.id
 

--- a/modules/cognito/outputs.tf
+++ b/modules/cognito/outputs.tf
@@ -61,3 +61,13 @@ output "control_plane_service_client_secret" {
   description = "The client secret for the control plane service."
   value       = aws_cognito_user_pool_client.control_plane_service_client.client_secret
 }
+
+output "access_handler_service_client_id" {
+  description = "The client ID for the access handler service."
+  value       = aws_cognito_user_pool_client.access_handler_service_client.id
+}
+
+output "access_handler_service_client_secret" {
+  description = "The client secret for the access handler service."
+  value       = aws_cognito_user_pool_client.access_handler_service_client.client_secret
+}

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -107,9 +107,9 @@ locals {
 
 
 resource "aws_iam_policy" "parameter_store_secrets_read_access" {
-  count       = length(local.secret_arns) > 0 ? 1 : 0
+  count       = 1
   name        = "${var.namespace}-${var.stage}-control-plane-ps"
-  description = "Allows read secret from parameter store"
+  description = "Allows reading secrets from SSM Parameter Store"
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -119,9 +119,12 @@ resource "aws_iam_policy" "parameter_store_secrets_read_access" {
       {
         Effect = "Allow"
         Action = [
-          "ssm:GetParameters",
+          "ssm:GetParameter",
+          "ssm:GetParameters"
         ]
-        Resource = arn
+        Resource = [
+          "arn:${var.aws_partition}:ssm:${var.aws_region}:${var.aws_account_id}:parameter/${var.namespace}/${var.stage}/*",
+        ]
       }
     ]
   })

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -99,12 +99,6 @@ locals {
   }
 }
 
-locals {
-  task_secret_arns = {
-    for arn in var.parameter_store_secret_arns : arn => arn if arn != ""
-  }
-}
-
 
 resource "aws_iam_policy" "parameter_store_secrets_read_access" {
   count       = 1
@@ -132,7 +126,7 @@ resource "aws_iam_policy" "parameter_store_secrets_read_access" {
 
 
 resource "aws_iam_role_policy_attachment" "control_plane_ecs_task_parameter_store_secrets_read_access_attach" {
-  count      = length(local.secret_arns) > 0 ? 1 : 0
+  count      = 1
   role       = aws_iam_role.control_plane_ecs_execution_role.name
   policy_arn = aws_iam_policy.parameter_store_secrets_read_access[0].arn
 }
@@ -156,34 +150,6 @@ resource "aws_iam_role" "control_plane_ecs_task_role" {
   })
 }
 
-
-resource "aws_iam_policy" "task_role_parameter_store_secrets_read_access" {
-  count       = length(local.secret_arns) > 0 ? 1 : 0
-  name        = "${var.namespace}-${var.stage}-control-plane-ps-tr"
-  description = "Allows read secret from parameter store"
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    // include only the secrets that are configured
-    Statement = [
-      for arn in local.task_secret_arns :
-      {
-        Effect = "Allow"
-        // @TODO: Security revert this to the correct scoped permissions for only teh ssmn params read access
-        Action = [
-          "*",
-        ]
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "control_plane_ecs_task_task_role_parameter_store_secrets_read_access_attach" {
-  count      = length(local.secret_arns) > 0 ? 1 : 0
-  role       = aws_iam_role.control_plane_ecs_task_role.name
-  policy_arn = aws_iam_policy.task_role_parameter_store_secrets_read_access[0].arn
-}
 resource "aws_iam_policy" "eventbus_put_events" {
   name        = "${var.namespace}-${var.stage}-control-plane-eb"
   description = "Allows ECS tasks to put events to the event bus"

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -185,3 +185,15 @@ variable "parameter_store_secret_arns" {
   default     = []
   type        = list(string)
 }
+
+variable "aws_region" {
+  description = "The AWS region the module is being deployed to"
+}
+
+variable "aws_partition" {
+  description = "The AWS partition the module is being deployed to"
+}
+
+variable "aws_account_id" {
+  description = "The AWS account ID the module is being deployed to"
+}

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -186,10 +186,6 @@ variable "parameter_store_secret_arns" {
   type        = list(string)
 }
 
-variable "aws_region" {
-  description = "The AWS region the module is being deployed to"
-}
-
 variable "aws_partition" {
   description = "The AWS partition the module is being deployed to"
 }


### PR DESCRIPTION
Also fixes a bug caused by an invalid IAM document for SSM access. I've opted to give the Control Plane access to the entire SSM path - `common-fate/prod/*` by default. I think this greatly simplifies deployment and doesn't really have a security impact, especially as we recommend a dedicated account for all deployments.