### PR TITLE
Add support for entra to provisioner

### DIFF
--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -9,6 +9,7 @@
 terraform {
   experiments = [module_variable_optional_attrs]
 }
+data "aws_caller_identity" "current" {}
 
 locals {
   aws_idc_config = var.aws_idc_config != null ? var.aws_idc_config : {}
@@ -71,8 +72,9 @@ locals {
 
   entra_secrets = var.entra_config != null ? [
     {
-      name      = "CF_ENTRA_CLIENT_SECRET",
-      valueFrom = local.entra_config.client_secret_ps_arn
+      name = "CF_ENTRA_CLIENT_SECRET",
+      // construct the arn from a path to make configuration most simple and consistent accross infra and config
+      valueFrom = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.entra_config.client_secret_secret_path}"
     }
   ] : []
 

--- a/modules/provisioner/variables.tf
+++ b/modules/provisioner/variables.tf
@@ -125,7 +125,7 @@ variable "entra_config" {
   Configuration for GCP. The following keys are expected:
   - tenant_id: The Entra tenant ID.
   - client_id: The client ID for the Entra App Registration.
-  - client_secret_ps_arn: The SSM Parameter store secret path for the client secret for the Entra App Registration.
+  - client_secret_secret_path: The SSM Parameter store secret path for the client secret for the Entra App Registration.
   EOF
   type = object({
     tenant_id                 = string

--- a/modules/provisioner/variables.tf
+++ b/modules/provisioner/variables.tf
@@ -118,3 +118,20 @@ variable "gcp_config" {
     error_message = "At least one of 'service_account_client_json_ps_arn' or 'workload_identity_config_json' must be provided in 'gcp_config'."
   }
 }
+
+
+variable "entra_config" {
+  description = <<EOF
+  Configuration for GCP. The following keys are expected:
+  - tenant_id: The Entra tenant ID.
+  - client_id: The client ID for the Entra App Registration.
+  - client_secret_ps_arn: The SSM Parameter store secret path for the client secret for the Entra App Registration.
+  EOF
+  type = object({
+    tenant_id            = string
+    client_id            = string
+    client_secret_ps_arn = string
+  })
+  default = null
+
+}

--- a/modules/provisioner/variables.tf
+++ b/modules/provisioner/variables.tf
@@ -128,9 +128,9 @@ variable "entra_config" {
   - client_secret_ps_arn: The SSM Parameter store secret path for the client secret for the Entra App Registration.
   EOF
   type = object({
-    tenant_id            = string
-    client_id            = string
-    client_secret_ps_arn = string
+    tenant_id                 = string
+    client_id                 = string
+    client_secret_secret_path = string
   })
   default = null
 


### PR DESCRIPTION
Adds entra config to provisioner.
Ops to use an ssm path instead of an ARN because it is consistent with how you configure integrations