### PR TITLE
fix GCP variable key reference

### DIFF
--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -50,7 +50,7 @@ locals {
     }
   ] : []
 
-  gcp_secrets = var.gcp_config != null && local.gcp_config.service_account_client_json_ps_arn != null ? [
+  gcp_secrets = var.gcp_config != null && lookup(local.gcp_config, "service_account_client_json_ps_arn", null) != null ? [
     {
       name      = "CF_GCP_SERVICE_ACCOUNT_CREDENTIALS_JSON",
       valueFrom = local.gcp_config.service_account_client_json_ps_arn


### PR DESCRIPTION
Fixes a reference which resulted in a map key lookup error if the `gcp_config` variable was null.