### PR TITLE
Fix authz GRPC healthcheck

### DIFF
--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -226,6 +226,7 @@ resource "aws_lb_target_group" "grpc_tg" {
     port     = 5050
     protocol = "HTTP"
     path     = "/commonfate.authz.v1alpha1.HealthService/HealthCheck"
+    matcher  = "0"
   }
 
 }

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -223,9 +223,9 @@ resource "aws_lb_target_group" "grpc_tg" {
 
   health_check {
     enabled  = true
-    port     = 9090
+    port     = 5050
     protocol = "HTTP"
-    path     = "/health"
+    path     = "/commonfate.authz.v1alpha1.HealthService/HealthCheck"
   }
 
 }


### PR DESCRIPTION
Use GRPC for the healthcheck rather than the HTTP monitoring port.