### PR TITLE
Upgrade rds database and remove old security groups

### DIFF
--- a/.changeset/wet-pears-dance.md
+++ b/.changeset/wet-pears-dance.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+Breaking change: Reconfigure the rds database to use deletion protection and encryptio. This change cannot be rolled back without manual steps.

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -25,10 +25,6 @@ resource "aws_security_group" "ecs_access_handler_sg_v2" {
   }
 }
 
-// @TODO remove
-resource "aws_security_group" "ecs_access_handler_sg" {
-  vpc_id = var.vpc_id
-}
 
 
 resource "aws_cloudwatch_log_group" "access_handler_log_group" {

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -45,9 +45,7 @@ resource "aws_security_group" "ecs_authz_sg_v2" {
 
 
 }
-resource "aws_security_group" "ecs_authz_sg" {
-  vpc_id = var.vpc_id
-}
+
 
 resource "aws_cloudwatch_log_group" "authz_log_group" {
   name              = "${var.namespace}-${var.stage}-authz"

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -29,9 +29,7 @@ resource "aws_security_group" "ecs_control_plane_sg_v2" {
   }
 
 }
-resource "aws_security_group" "ecs_control_plane_sg" {
-  vpc_id = var.vpc_id
-}
+
 
 # Update the RDS security group to allow connections from the ECS control-plane service
 resource "aws_security_group_rule" "rds_access_from_control_plane" {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -29,7 +29,7 @@ resource "aws_db_instance" "pg_db" {
   skip_final_snapshot         = true
   db_subnet_group_name        = var.subnet_group_id
   vpc_security_group_ids      = [aws_security_group.rds_sg.id]
-  # storage_encrypted            = true
-  # deletion_protection          = true
-  # performance_insights_enabled = true
+  storage_encrypted            = true
+  deletion_protection          = true
+  performance_insights_enabled = true
 }

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -146,9 +146,7 @@ resource "aws_security_group" "ecs_provisioner_sg_v2" {
   }
 }
 
-resource "aws_security_group" "ecs_provisioner_sg" {
-  vpc_id = var.vpc_id
-}
+
 
 resource "aws_cloudwatch_log_group" "provisioner_log_group" {
   name              = "${local.name_prefix}-provisioner"

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -28,9 +28,6 @@ resource "aws_security_group" "ecs_web_sg_v2" {
 
 }
 
-resource "aws_security_group" "ecs_web_sg" {
-  vpc_id = var.vpc_id
-}
 
 resource "aws_iam_role" "web_ecs_execution_role" {
   name = "${var.namespace}-${var.stage}-web-ecs-er"


### PR DESCRIPTION
Extends on work in #22 

Applies updates to the rds database
- Deletion protection
- Encryption

Removes old security groups
- These old security groups were replaced in the v1.8.0 release and need to be removed as a 2 stage process.

Due to the database encryption and deletion protection, this change cannot be rolled back to pre v2.0.0 infrastructure versions