### PR TITLE
Fix default logo URL pointing to a broken image

### DIFF
--- a/.changeset/cool-eels-attend.md
+++ b/.changeset/cool-eels-attend.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fixes an issue where the default logo URL pointed to a broken image if a custom logo wasn't provided for the deployment

--- a/examples/existing_vpc/variables.tf
+++ b/examples/existing_vpc/variables.tf
@@ -90,7 +90,7 @@ variable "team_name" {
 
 variable "logo_url" {
   description = "Specifies a public logo URL for frontend branding."
-  default     = "https://commonfate.io/logo.png"
+  default     = ""
   type        = string
 }
 

--- a/examples/full/variables.tf
+++ b/examples/full/variables.tf
@@ -90,7 +90,7 @@ variable "team_name" {
 
 variable "logo_url" {
   description = "Specifies a public logo URL for frontend branding."
-  default     = "https://commonfate.io/logo.png"
+  default     = ""
   type        = string
 }
 

--- a/examples/simple/variables.tf
+++ b/examples/simple/variables.tf
@@ -89,7 +89,7 @@ variable "team_name" {
 
 variable "logo_url" {
   description = "Specifies a public logo URL for frontend branding."
-  default     = "https://commonfate.io/logo.png"
+  default     = ""
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -90,7 +90,7 @@ variable "team_name" {
 
 variable "logo_url" {
   description = "Specifies a public logo URL for frontend branding."
-  default     = "https://commonfate.io/logo.png"
+  default     = ""
   type        = string
 }
 


### PR DESCRIPTION
By default, it should be empty so that the inline Common Fate logo SVG shows up.