### PR TITLE
Provisioner: add optional variable for IAM Identity Center Identity Store ID

### DIFF
--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -40,6 +40,10 @@ locals {
     {
       name  = "CF_AWS_IDC_INSTANCE_ARN"
       value = local.aws_idc_config.idc_instance_arn
+    },
+    {
+      name  = "CF_AWS_IDC_IDENTITY_STORE_ID"
+      value = coalesce(local.aws_idc_config.idc_identity_store_id, "")
     }
   ] : []
 

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -43,7 +43,7 @@ locals {
     },
     {
       name  = "CF_AWS_IDC_IDENTITY_STORE_ID"
-      value = coalesce(local.aws_idc_config.idc_identity_store_id, "")
+      value = local.aws_idc_config.idc_identity_store_id
     }
   ] : []
 

--- a/modules/provisioner/variables.tf
+++ b/modules/provisioner/variables.tf
@@ -113,11 +113,15 @@ variable "aws_idc_config" {
   - role_arn: The ARN of the IAM role for the provisioner to assume which hass permissions to provision access in an AWS organization.
   - idc_region: The AWS IDC Region.
   - idc_instance_arn: The AWS Identity Center instance ARN.
+  - idc_identity_store_id: The AWS IAM Identity Center Identity Store ID.
   EOF
   type = object({
     role_arn         = string
     idc_region       = string
     idc_instance_arn = string
+
+    // optional for the moment to avoid making breaking changes.
+    idc_identity_store_id = optional(string)
   })
   default = null
 }


### PR DESCRIPTION
Required for the IAM Identity Center JIT group assignment integration.