### PR TITLE
removes rds table encryption for now

### DIFF
--- a/.changeset/wet-pears-dance.md
+++ b/.changeset/wet-pears-dance.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+Breaking change: Reconfigure the rds database to use deletion protection and encryptio. This change cannot be rolled back without manual steps.

--- a/.changeset/wet-pears-dance.md
+++ b/.changeset/wet-pears-dance.md
@@ -1,5 +1,0 @@
----
-"@common-fate/terraform-aws-common-fate-deployment": major
----
-
-Breaking change: Reconfigure the rds database to use deletion protection and encryptio. This change cannot be rolled back without manual steps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @common-fate/terraform-aws-common-fate-deployment
 
+## 2.0.0
+
+### Major Changes
+
+- 568caa2: Breaking change: Reconfigure the rds database to use deletion protection and encryptio. This change cannot be rolled back without manual steps.
+
 ## 1.8.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # @common-fate/terraform-aws-common-fate-deployment
 
-## 2.0.0
+## 1.9.0
 
-### Major Changes
+### Minor Changes
 
-- 568caa2: Breaking change: Reconfigure the rds database to use deletion protection and encryptio. This change cannot be rolled back without manual steps.
+- 568caa2: Reconfigure the rds database to use deletion protection.
 
 ## 1.8.0
 

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -25,10 +25,6 @@ resource "aws_security_group" "ecs_access_handler_sg_v2" {
   }
 }
 
-// @TODO remove
-resource "aws_security_group" "ecs_access_handler_sg" {
-  vpc_id = var.vpc_id
-}
 
 
 resource "aws_cloudwatch_log_group" "access_handler_log_group" {

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -45,9 +45,7 @@ resource "aws_security_group" "ecs_authz_sg_v2" {
 
 
 }
-resource "aws_security_group" "ecs_authz_sg" {
-  vpc_id = var.vpc_id
-}
+
 
 resource "aws_cloudwatch_log_group" "authz_log_group" {
   name              = "${var.namespace}-${var.stage}-authz"

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -29,9 +29,7 @@ resource "aws_security_group" "ecs_control_plane_sg_v2" {
   }
 
 }
-resource "aws_security_group" "ecs_control_plane_sg" {
-  vpc_id = var.vpc_id
-}
+
 
 # Update the RDS security group to allow connections from the ECS control-plane service
 resource "aws_security_group_rule" "rds_access_from_control_plane" {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -29,7 +29,7 @@ resource "aws_db_instance" "pg_db" {
   skip_final_snapshot         = true
   db_subnet_group_name        = var.subnet_group_id
   vpc_security_group_ids      = [aws_security_group.rds_sg.id]
-  # storage_encrypted            = true
-  # deletion_protection          = true
-  # performance_insights_enabled = true
+  storage_encrypted            = true
+  deletion_protection          = true
+  performance_insights_enabled = true
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -17,19 +17,18 @@ resource "aws_db_parameter_group" "postgres_db" {
 }
 
 resource "aws_db_instance" "pg_db" {
-  identifier                  = "${var.namespace}-${var.stage}-pg-db"
-  allocated_storage           = 20
-  engine                      = "postgres"
-  engine_version              = "15.4"
-  instance_class              = "db.t3.micro"
-  db_name                     = "postgres"
-  username                    = "postgres"
-  manage_master_user_password = true
-  parameter_group_name        = aws_db_parameter_group.postgres_db.name
-  skip_final_snapshot         = true
-  db_subnet_group_name        = var.subnet_group_id
-  vpc_security_group_ids      = [aws_security_group.rds_sg.id]
-  storage_encrypted            = true
+  identifier                   = "${var.namespace}-${var.stage}-pg-db"
+  allocated_storage            = 20
+  engine                       = "postgres"
+  engine_version               = "15.4"
+  instance_class               = "db.t3.micro"
+  db_name                      = "postgres"
+  username                     = "postgres"
+  manage_master_user_password  = true
+  parameter_group_name         = aws_db_parameter_group.postgres_db.name
+  skip_final_snapshot          = true
+  db_subnet_group_name         = var.subnet_group_id
+  vpc_security_group_ids       = [aws_security_group.rds_sg.id]
   deletion_protection          = true
   performance_insights_enabled = true
 }

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -146,9 +146,7 @@ resource "aws_security_group" "ecs_provisioner_sg_v2" {
   }
 }
 
-resource "aws_security_group" "ecs_provisioner_sg" {
-  vpc_id = var.vpc_id
-}
+
 
 resource "aws_cloudwatch_log_group" "provisioner_log_group" {
   name              = "${local.name_prefix}-provisioner"

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -28,9 +28,6 @@ resource "aws_security_group" "ecs_web_sg_v2" {
 
 }
 
-resource "aws_security_group" "ecs_web_sg" {
-  vpc_id = var.vpc_id
-}
 
 resource "aws_iam_role" "web_ecs_execution_role" {
   name = "${var.namespace}-${var.stage}-web-ecs-er"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@common-fate/terraform-aws-common-fate-deployment",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
Enabling `storage_encryption` requires a destroy and recreate of the database. This will be removed for the time being until a proper snapshot and restore workflow has been created.