### PR TITLE
Allow overriding API URLs

### DIFF
--- a/.changeset/purple-walls-fry.md
+++ b/.changeset/purple-walls-fry.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds variables to customise API URLs and CORS allowed origins

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ module "control_plane" {
   otel_log_group_name                 = module.ecs_base.otel_log_group_name
   otel_writer_iam_policy_arn          = module.ecs_base.otel_writer_iam_policy_arn
   alb_security_group_id               = module.alb.alb_security_group_id
-
+  cors_allowed_origins                = var.cors_allowed_origins
 }
 
 
@@ -158,7 +158,7 @@ module "access_handler" {
   otel_log_group_name                       = module.ecs_base.otel_log_group_name
   otel_writer_iam_policy_arn                = module.ecs_base.otel_writer_iam_policy_arn
   alb_security_group_id                     = module.alb.alb_security_group_id
-
+  cors_allowed_origins                      = var.cors_allowed_origins
 }
 
 module "authz" {
@@ -182,6 +182,6 @@ module "authz" {
   oidc_control_plane_client_id          = module.cognito.control_plane_service_client_id
   oidc_provisioner_service_client_id    = module.cognito.provisioner_client_id
   alb_security_group_id                 = module.alb.alb_security_group_id
-
+  cors_allowed_origins                  = var.cors_allowed_origins
 }
 

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ module "control_plane" {
   otel_log_group_name                 = module.ecs_base.otel_log_group_name
   otel_writer_iam_policy_arn          = module.ecs_base.otel_writer_iam_policy_arn
   alb_security_group_id               = module.alb.alb_security_group_id
-  cors_allowed_origins                = var.cors_allowed_origins
+  additional_cors_allowed_origins     = var.additional_cors_allowed_origins
 }
 
 
@@ -158,7 +158,7 @@ module "access_handler" {
   otel_log_group_name                       = module.ecs_base.otel_log_group_name
   otel_writer_iam_policy_arn                = module.ecs_base.otel_writer_iam_policy_arn
   alb_security_group_id                     = module.alb.alb_security_group_id
-  cors_allowed_origins                      = var.cors_allowed_origins
+  additional_cors_allowed_origins           = var.additional_cors_allowed_origins
 }
 
 module "authz" {
@@ -182,6 +182,6 @@ module "authz" {
   oidc_control_plane_client_id          = module.cognito.control_plane_service_client_id
   oidc_provisioner_service_client_id    = module.cognito.provisioner_client_id
   alb_security_group_id                 = module.alb.alb_security_group_id
-  cors_allowed_origins                  = var.cors_allowed_origins
+  additional_cors_allowed_origins       = var.additional_cors_allowed_origins
 }
 

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -139,7 +139,7 @@ resource "aws_ecs_task_definition" "access_handler_task" {
           value = var.auth_issuer
         },
         { name  = "CF_CORS_ALLOWED_ORIGINS"
-          value = join(",", [concat([var.app_url], var.additional_cors_allowed_origins)])
+          value = join(",", concat([var.app_url], var.additional_cors_allowed_origins))
         },
         {
           name  = "LOG_LEVEL"

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -139,7 +139,7 @@ resource "aws_ecs_task_definition" "access_handler_task" {
           value = var.auth_issuer
         },
         { name  = "CF_CORS_ALLOWED_ORIGINS"
-          value = join(",", [var.app_url])
+          value = join(",", [concat([var.app_url], var.cors_allowed_origins)])
         },
         {
           name  = "LOG_LEVEL"

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -139,7 +139,7 @@ resource "aws_ecs_task_definition" "access_handler_task" {
           value = var.auth_issuer
         },
         { name  = "CF_CORS_ALLOWED_ORIGINS"
-          value = join(",", [concat([var.app_url], var.cors_allowed_origins)])
+          value = join(",", [concat([var.app_url], var.additional_cors_allowed_origins)])
         },
         {
           name  = "LOG_LEVEL"

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -120,3 +120,9 @@ variable "alb_security_group_id" {
   type        = string
   description = "the security group id for the outward facing alb"
 }
+
+variable "cors_allowed_origins" {
+  type        = list(string)
+  default     = []
+  description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."
+}

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -121,7 +121,7 @@ variable "alb_security_group_id" {
   description = "the security group id for the outward facing alb"
 }
 
-variable "cors_allowed_origins" {
+variable "additional_cors_allowed_origins" {
   type        = list(string)
   default     = []
   description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -180,7 +180,7 @@ resource "aws_ecs_task_definition" "authz_task" {
         value = var.dynamodb_table_name
       },
       { name  = "CF_CORS_ALLOWED_ORIGINS"
-        value = join(",", [var.app_url])
+        value = join(",", [concat([var.app_url], var.cors_allowed_origins)])
       },
       {
         name  = "LOG_LEVEL"

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -180,7 +180,7 @@ resource "aws_ecs_task_definition" "authz_task" {
         value = var.dynamodb_table_name
       },
       { name  = "CF_CORS_ALLOWED_ORIGINS"
-        value = join(",", [concat([var.app_url], var.cors_allowed_origins)])
+        value = join(",", [concat([var.app_url], var.additional_cors_allowed_origins)])
       },
       {
         name  = "LOG_LEVEL"

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -180,7 +180,7 @@ resource "aws_ecs_task_definition" "authz_task" {
         value = var.dynamodb_table_name
       },
       { name  = "CF_CORS_ALLOWED_ORIGINS"
-        value = join(",", [concat([var.app_url], var.additional_cors_allowed_origins)])
+        value = join(",", concat([var.app_url], var.additional_cors_allowed_origins))
       },
       {
         name  = "LOG_LEVEL"

--- a/modules/authz/variables.tf
+++ b/modules/authz/variables.tf
@@ -121,3 +121,9 @@ variable "alb_security_group_id" {
   type        = string
   description = "the security group id for the outward facing alb"
 }
+
+variable "cors_allowed_origins" {
+  type        = list(string)
+  default     = []
+  description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."
+}

--- a/modules/authz/variables.tf
+++ b/modules/authz/variables.tf
@@ -122,7 +122,7 @@ variable "alb_security_group_id" {
   description = "the security group id for the outward facing alb"
 }
 
-variable "cors_allowed_origins" {
+variable "additional_cors_allowed_origins" {
   type        = list(string)
   default     = []
   description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."

--- a/modules/cognito/outputs.tf
+++ b/modules/cognito/outputs.tf
@@ -83,3 +83,8 @@ output "access_handler_service_client_secret" {
   description = "The client secret for the access handler service."
   value       = aws_cognito_user_pool_client.access_handler_service_client.client_secret
 }
+
+output "identity_provider_name" {
+  description = "The name of the Cognito identity provider"
+  value       = local.identity_provider_name
+}

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -324,7 +324,7 @@ resource "aws_ecs_task_definition" "control_plane_task" {
           value = var.oidc_control_plane_issuer
         },
         { name  = "CF_CORS_ALLOWED_ORIGINS"
-          value = join(",", [concat([var.app_url], var.additional_cors_allowed_origins)])
+          value = join(",", concat([var.app_url], var.additional_cors_allowed_origins))
         },
         {
           name  = "LOG_LEVEL"

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -324,7 +324,7 @@ resource "aws_ecs_task_definition" "control_plane_task" {
           value = var.oidc_control_plane_issuer
         },
         { name  = "CF_CORS_ALLOWED_ORIGINS"
-          value = join(",", [concat([var.app_url], var.cors_allowed_origins)])
+          value = join(",", [concat([var.app_url], var.additional_cors_allowed_origins)])
         },
         {
           name  = "LOG_LEVEL"

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -324,7 +324,7 @@ resource "aws_ecs_task_definition" "control_plane_task" {
           value = var.oidc_control_plane_issuer
         },
         { name  = "CF_CORS_ALLOWED_ORIGINS"
-          value = join(",", [var.app_url])
+          value = join(",", [concat([var.app_url], var.cors_allowed_origins)])
         },
         {
           name  = "LOG_LEVEL"

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -212,3 +212,10 @@ variable "alb_security_group_id" {
   description = "the security group id for the outward facing alb"
 }
 
+
+
+variable "cors_allowed_origins" {
+  type        = list(string)
+  default     = []
+  description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."
+}

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -214,7 +214,7 @@ variable "alb_security_group_id" {
 
 
 
-variable "cors_allowed_origins" {
+variable "additional_cors_allowed_origins" {
   type        = list(string)
   default     = []
   description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -169,7 +169,7 @@ resource "aws_ecs_service" "web_service" {
 }
 resource "aws_lb_listener_rule" "service_rule" {
   listener_arn = var.alb_listener_arn
-  priority     = 100
+  priority     = var.alb_listener_rule_priority
   action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.web_tg.arn

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -92,19 +92,19 @@ resource "aws_ecs_task_definition" "web_task" {
       },
       {
         name  = "CF_API_URL"
-        value = var.app_url
+        value = coalesce(var.controlplane_api_url, var.app_url)
       },
       {
         name  = "CF_ACCESS_API_URL"
-        value = var.app_url
+        value = coalesce(var.access_api_url, var.app_url)
       },
       {
         name  = "CF_AUTHZ_URL",
-        value = var.app_url
+        value = coalesce(var.authz_api_url, var.app_url)
       },
       {
         name  = "CF_AUTHZ_GRAPH_URL",
-        value = "${var.app_url}/graph"
+        value = "${coalesce(var.authz_api_url, var.app_url)}/graph"
       },
       {
         name  = "CF_TEAM_NAME"

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -133,5 +133,11 @@ variable "desired_task_count" {
 
 variable "alb_security_group_id" {
   type        = string
-  description = "the security group id for the outward facing alb"
+  description = "the ALB security group ID."
+}
+
+variable "alb_listener_rule_priority" {
+  type        = number
+  description = "Listener priority for the ALB rule to route traffic to the service."
+  default     = 100
 }

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -25,6 +25,27 @@ variable "release_tag" {
   type        = string
 }
 
+variable "controlplane_api_url" {
+  description = "The Control Plane API url (e.g., 'https://common-fate.mydomain.com')."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "access_api_url" {
+  description = "The Access API url (e.g., 'https://common-fate.mydomain.com')."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "authz_api_url" {
+  description = "The Authz API url (e.g., 'https://common-fate.mydomain.com')."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
 variable "app_url" {
   description = "The app url (e.g., 'https://common-fate.mydomain.com')."
   type        = string
@@ -34,6 +55,7 @@ variable "app_url" {
     error_message = "The app_url must start with 'https://'."
   }
 }
+
 variable "aws_region" {
   description = "Determines the AWS Region for deployment."
   type        = string

--- a/outputs.tf
+++ b/outputs.tf
@@ -130,3 +130,23 @@ output "event_bus_log_group_name" {
   description = "The Event Bus log group name."
   value       = module.events.event_bus_log_group_name
 }
+
+output "alb_listener_arn" {
+  description = "The ALB Listener ARN."
+  value       = module.alb.listener_arn
+}
+
+output "auth_authority_url" {
+  description = "The OIDC authority URL."
+  value       = module.cognito.auth_authority_url
+}
+
+output "alb_security_group_id" {
+  description = "The ALB Security Group ID."
+  value       = module.alb.alb_security_group_id
+}
+
+output "cognito_identity_provider_name" {
+  description = "The Cognito identity provider name."
+  value       = module.cognito.identity_provider_name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,6 +30,8 @@ output "outputs" {
     ecs_cluster_id                   = module.ecs.cluster_id
     auth_issuer                      = module.cognito.auth_issuer
     event_bus_log_group_name         = module.events.event_bus_log_group_name
+    cognito_user_pool_id             = module.cognito.user_pool_id
+    cognito_identity_provider_name   = module.cognito.identity_provider_name
   }
 }
 
@@ -149,4 +151,10 @@ output "alb_security_group_id" {
 output "cognito_identity_provider_name" {
   description = "The Cognito identity provider name."
   value       = module.cognito.identity_provider_name
+}
+
+
+output "cognito_user_pool_id" {
+  description = "The Cognito user pool ID."
+  value       = module.cognito.user_pool_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -158,7 +158,7 @@ variable "authz_log_level" {
   default     = "INFO"
 }
 
-variable "cors_allowed_origins" {
+variable "additional_cors_allowed_origins" {
   type        = list(string)
   default     = []
   description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."

--- a/variables.tf
+++ b/variables.tf
@@ -157,3 +157,9 @@ variable "authz_log_level" {
   type        = string
   default     = "INFO"
 }
+
+variable "cors_allowed_origins" {
+  type        = list(string)
+  default     = []
+  description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."
+}


### PR DESCRIPTION
Allows customising API URLs and CORS origins. Internally we are using these changes to run a second copy of the web UI to preview some changes against the existing APIs.

Exposes a bunch of additional outputs from the deployment to allow additional Cognito clients to be created.