### PR TITLE
add optional permissions for IAM Identity Center group membership management

### DIFF
--- a/.changeset/curly-keys-dance.md
+++ b/.changeset/curly-keys-dance.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+IAM Identity Center integration: adds optional permissions to allow management of group memberships

--- a/modules/aws-idc-integration/iam-roles/main.tf
+++ b/modules/aws-idc-integration/iam-roles/main.tf
@@ -153,6 +153,9 @@ resource "aws_iam_policy" "idc_provision_group_membership" {
         "Action" : [
           "identitystore:CreateGroupMembership",
           "identitystore:DeleteGroupMembership",
+          "identitystore:ListGroupMembershipsForMember",
+          "identitystore:IsMemberInGroups",
+          "identitystore:ListGroupMemberships"
         ],
         "Resource" : "*"
       }

--- a/modules/aws-idc-integration/iam-roles/main.tf
+++ b/modules/aws-idc-integration/iam-roles/main.tf
@@ -164,7 +164,7 @@ resource "aws_iam_policy" "idc_provision_group_membership" {
 resource "aws_iam_role_policy_attachment" "idc_provision_idc_provision_group_membership_role_policy_attach" {
   count      = var.permit_group_assignment ? 1 : 0
   role       = aws_iam_role.provision_role.name
-  policy_arn = aws_iam_policy.idc_provision_idc_provision_group_membership[0].arn
+  policy_arn = aws_iam_policy.idc_provision_group_membership[0].arn
 }
 
 

--- a/modules/aws-idc-integration/iam-roles/main.tf
+++ b/modules/aws-idc-integration/iam-roles/main.tf
@@ -138,3 +138,33 @@ resource "aws_iam_role_policy_attachment" "idc_provision_management_account_role
 }
 
 
+// an optional additional policy allowing IAM Identity Center group management
+resource "aws_iam_policy" "idc_provision_group_membership" {
+  count       = var.permit_group_assignment ? 1 : 0
+  name        = "${var.namespace}-${var.stage}-idc-provision-groups"
+  description = "Allows Common Fate to provision access to AWS IAM Identity Center groups"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "AssignGroups",
+        "Effect" : "Allow",
+        "Action" : [
+          "identitystore:CreateGroupMembership",
+          "identitystore:DeleteGroupMembership",
+        ],
+        "Resource" : "*"
+      }
+
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "idc_provision_idc_provision_group_membership_role_policy_attach" {
+  count      = var.permit_group_assignment ? 1 : 0
+  role       = aws_iam_role.provision_role.name
+  policy_arn = aws_iam_policy.idc_provision_idc_provision_group_membership[0].arn
+}
+
+

--- a/modules/aws-idc-integration/iam-roles/variables.tf
+++ b/modules/aws-idc-integration/iam-roles/variables.tf
@@ -24,4 +24,9 @@ variable "permit_management_account_assignments" {
   default     = false
 }
 
+variable "permit_group_assignment" {
+  description = "By default, the AWS IAM role for the provisioner does not have the required permissions to manage IAM Identity Center group memberships. You can enable that feature with this flag set to true"
+  type        = bool
+  default     = false
+}
 


### PR DESCRIPTION
these are disabled by default and can be enabled using the `permit_group_assignment` variable