### PR TITLE
Add builtin provisioner

### DIFF
--- a/.changeset/clever-spiders-drum.md
+++ b/.changeset/clever-spiders-drum.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Add https:// prefix back to cognito outputs after custom domain change

--- a/.changeset/serious-tips-bathe.md
+++ b/.changeset/serious-tips-bathe.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Deploy a provisioner as part of the main stack

--- a/.changeset/shiny-jobs-dance.md
+++ b/.changeset/shiny-jobs-dance.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fix the cognito module typo for the random_pet module

--- a/main.tf
+++ b/main.tf
@@ -185,3 +185,25 @@ module "authz" {
   additional_cors_allowed_origins       = var.additional_cors_allowed_origins
 }
 
+module "provisioner" {
+  source = "./modules/provisioner"
+  // A name prefix is used so that this builtin provisioner may be deployed without causing downtime when migrating from an external provisioner deployment
+  name_prefix                       = "builtin"
+  namespace                         = var.namespace
+  stage                             = var.stage
+  aws_region                        = var.aws_region
+  release_tag                       = var.release_tag
+  access_handler_sg_id              = module.access_handler.security_group_id
+  subnet_ids                        = module.vpc.private_subnet_ids
+  vpc_id                            = module.vpc.vpc_id
+  ecs_cluster_id                    = module.ecs.cluster_id
+  provisioner_service_client_id     = module.cognito.provisioner_client_id
+  provisioner_service_client_secret = module.cognito.provisioner_client_secret
+  auth_issuer                       = module.cognito.auth_issuer
+  app_url                           = var.app_url
+
+  gcp_config     = var.provisioner_gcp_config
+  aws_idc_config = var.provisioner_aws_idc_config
+  entra_config   = var.provisioner_entra_config
+  aws_rds_config = var.provisioner_aws_rds_config
+}

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -169,7 +169,7 @@ locals {
 }
 // Optionally configure a custom domain if the auth_url and auth_certificate_arn are provided
 resource "aws_cognito_user_pool_domain" "custom_domain" {
-  domain          = local.has_custom_domain ? replace(var.auth_url, "https://", "") : random_id.auth_domain_prefix.id
+  domain          = local.has_custom_domain ? replace(var.auth_url, "https://", "") : random_pet.auth_domain_prefix.id
   user_pool_id    = aws_cognito_user_pool.cognito_user_pool.id
   certificate_arn = local.has_custom_domain ? var.auth_certificate_arn : null
 }

--- a/modules/cognito/outputs.tf
+++ b/modules/cognito/outputs.tf
@@ -9,12 +9,12 @@ output "saml_entity_id" {
 
 output "saml_acs_url" {
   description = "The Cognito Assertion Consumer Service (ACS) URL required for SAML configuration."
-  value       = "${aws_cognito_user_pool_domain.custom_domain.domain}/saml2/idpresponse"
+  value       = "https://${aws_cognito_user_pool_domain.custom_domain.domain}/saml2/idpresponse"
 }
 
 output "auth_url" {
   description = "The Cognito Auth URL will be either the custom domain if configured or a generated cognito domain."
-  value       = aws_cognito_user_pool_domain.custom_domain.domain
+  value       = "https://${aws_cognito_user_pool_domain.custom_domain.domain}"
 }
 
 

--- a/modules/provisioner/outputs.tf
+++ b/modules/provisioner/outputs.tf
@@ -11,3 +11,8 @@ output "task_role_arn" {
   value       = aws_iam_role.provisioner_ecs_task_role.arn
 }
 
+output "task_role_name" {
+  description = "The ARN of the IAM role assumed by the task"
+  value       = aws_iam_role.provisioner_ecs_task_role.arn
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,7 @@ output "outputs" {
     cognito_user_pool_id             = module.cognito.user_pool_id
     cognito_identity_provider_name   = module.cognito.identity_provider_name
     provisioner_task_role_arn        = module.provisioner.task_role_arn
+     provisioner_task_role_name        = module.provisioner.task_role_name
     provisioner_url                  = module.provisioner.provisioner_url
   }
 }
@@ -50,6 +51,11 @@ output "sensitive_outputs" {
 output "provisioner_task_role_arn" {
   description = "The task role arn of the builtin provisioner module"
   value       = module.provisioner.task_role_arn
+}
+
+output "provisioner_task_role_name" {
+  description = "The task role name of the builtin provisioner module"
+  value       = module.provisioner.task_role_name
 }
 
 output "provisioner_url" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,7 @@ output "outputs" {
     event_bus_log_group_name         = module.events.event_bus_log_group_name
     cognito_user_pool_id             = module.cognito.user_pool_id
     cognito_identity_provider_name   = module.cognito.identity_provider_name
+    provisioner_task_role_arn        = module.provisioner.task_role_arn
   }
 }
 
@@ -43,6 +44,11 @@ output "sensitive_outputs" {
     terraform_client_secret   = module.cognito.terraform_client_secret
     provisioner_client_secret = module.cognito.provisioner_client_secret
   }
+}
+
+output "provisioner_task_role_arn" {
+  description = "The task role arn of the builtin provisioner module"
+  value       = module.provisioner.task_role_arn
 }
 
 output "cognito_saml_entity_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,7 @@ output "outputs" {
     cognito_user_pool_id             = module.cognito.user_pool_id
     cognito_identity_provider_name   = module.cognito.identity_provider_name
     provisioner_task_role_arn        = module.provisioner.task_role_arn
+    provisioner_url                  = module.provisioner.provisioner_url
   }
 }
 
@@ -50,6 +51,12 @@ output "provisioner_task_role_arn" {
   description = "The task role arn of the builtin provisioner module"
   value       = module.provisioner.task_role_arn
 }
+
+output "provisioner_url" {
+  description = "The private ecs url of provisioner module"
+  value       = module.provisioner.provisioner_url
+}
+
 
 output "cognito_saml_entity_id" {
   description = "The cognito entity ID required for SAML configuration"

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,7 +33,7 @@ output "outputs" {
     cognito_user_pool_id             = module.cognito.user_pool_id
     cognito_identity_provider_name   = module.cognito.identity_provider_name
     provisioner_task_role_arn        = module.provisioner.task_role_arn
-     provisioner_task_role_name        = module.provisioner.task_role_name
+    provisioner_task_role_name       = module.provisioner.task_role_name
     provisioner_url                  = module.provisioner.provisioner_url
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "aws_region" {
 }
 
 variable "release_tag" {
-  description = "Specifies the tag for frontend and backend images, typically the git commit hash."
+  description = "Specifies the tag for frontend and backend images, e.g v1.2.0"
   type        = string
 }
 
@@ -161,4 +161,73 @@ variable "additional_cors_allowed_origins" {
   type        = list(string)
   default     = []
   description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."
+}
+
+
+variable "provisioner_aws_idc_config" {
+  description = <<EOF
+  Configuration for AWS IDC. The following keys are expected:
+  - role_arn: The ARN of the IAM role for the provisioner to assume which hass permissions to provision access in an AWS organization.
+  - idc_region: The AWS IDC Region.
+  - idc_instance_arn: The AWS Identity Center instance ARN.
+  - idc_identity_store_id: The AWS IAM Identity Center Identity Store ID.
+  EOF
+  type = object({
+    role_arn              = string
+    idc_region            = string
+    idc_instance_arn      = string
+    idc_identity_store_id = string
+  })
+  default = null
+}
+
+variable "provisioner_gcp_config" {
+  description = <<EOF
+  Configuration for GCP. The following keys are expected:
+  - service_account_client_json_ps_arn: (Optional) when using service account credentials, this is ARN of the secret credentials.
+  - workload_identity_config_json: (Optional) using Workload Identity Federation, this is the config file.
+
+  Either `workload_identity_config_json` or `service_account_client_json_ps_arn` must be provided (not both).
+  EOF
+  type = object({
+    service_account_client_json_ps_arn = optional(string)
+    workload_identity_config_json      = optional(string)
+  })
+  default = null
+}
+
+
+variable "provisioner_entra_config" {
+  description = <<EOF
+  Configuration for GCP. The following keys are expected:
+  - tenant_id: The Entra tenant ID.
+  - client_id: The client ID for the Entra App Registration.
+  - client_secret_secret_path: The SSM Parameter store secret path for the client secret for the Entra App Registration.
+  EOF
+  type = object({
+    tenant_id                 = string
+    client_id                 = string
+    client_secret_secret_path = string
+  })
+  default = null
+}
+
+
+variable "provisioner_aws_rds_config" {
+  description = <<EOF
+  Configuration for AWS RDS. The following keys are expected:
+  - role_arn: The ARN of the IAM role for the provisioner to assume which hass permissions to provision access in an AWS organization.
+  - idc_region: The AWS IDC Region.
+  - idc_instance_arn: The AWS Identity Center instance ARN.
+  - infra_role_name: The name of the IAM role which is deployed each each account containing databases.
+  - should_provision_security_groups: (Optional) Whether or not the provisioner should attempt to provision security groups. Set this to true if you are not using pre deployed security groups.
+  EOF
+  type = object({
+    idc_role_arn                     = string
+    idc_region                       = string
+    idc_instance_arn                 = string
+    infra_role_name                  = string
+    should_provision_security_groups = optional(bool)
+  })
+  default = null
 }


### PR DESCRIPTION
Adds a builtin deployment of the provisioner module

This will allow you to easily configure an integration to one instance of each like aws idc or gcloud.
You can still deploy the provisioner on its own to be able to connect to a second instance of one of the integrations.

on the main module the provisioner variables have been prefixed with "provisioner_" to make it clear what they are for.

This should be a non breaking change and can be upgraded to easily for existing teams, though no action is required.

I have chosen to make the ` idc_identity_store_id = string` mandatory on the main module config blocks only,  so when updating to the new configuration, this will need to be provided.