### PR TITLE
Relax database version constraint

### DIFF
--- a/.changeset/gorgeous-coats-attack.md
+++ b/.changeset/gorgeous-coats-attack.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Relax the AWS RDS database version constraint to be '15' rather than '15.4'. This fixes an issue where deployment updates could fail due to automatic minor version updates.

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -21,7 +21,7 @@ resource "aws_db_instance" "pg_db" {
   identifier                   = "${var.namespace}-${var.stage}-pg-db"
   allocated_storage            = 20
   engine                       = "postgres"
-  engine_version               = "15.4"
+  engine_version               = "15"
   instance_class               = "db.t3.micro"
   db_name                      = "postgres"
   username                     = "postgres"


### PR DESCRIPTION
Relaxes the constraint to just the major version.