### PR TITLE
set default null value for assume role external ID

### DIFF
--- a/.changeset/short-keys-brush.md
+++ b/.changeset/short-keys-brush.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+The Assume Role External ID is now set to `null` by default, rather than being a required (but nullable) variable.

--- a/variables.tf
+++ b/variables.tf
@@ -249,7 +249,7 @@ variable "assume_role_external_id" {
   type        = string
   nullable    = true
   description = "External ID to use when assuming cross-account AWS roles for auditing and provisioning."
-
+  default     = null
 }
 
 variable "control_plane_grant_assume_on_role_arns" {


### PR DESCRIPTION
Currently it's required which doesn't align with our getting started docs.