### PR TITLE
Josh/cf 2875 update aws idc roles module to support external id and

### DIFF
--- a/.changeset/dry-beans-retire.md
+++ b/.changeset/dry-beans-retire.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Update the AWS IDC Roles module to support an AWS account principal and external ID

--- a/modules/aws-idc-integration/iam-roles/main.tf
+++ b/modules/aws-idc-integration/iam-roles/main.tf
@@ -11,7 +11,7 @@ data "aws_iam_policy_document" "assume_roles_policy" {
     
     principals {
       type = length(local.trusted_principals) > 0 ? "AWS":"*"
-      identifiers = length(local.trusted_principals) > 0 ? local.trusted_principals:"*"
+      identifiers = length(local.trusted_principals) > 0 ? local.trusted_principals:["*"]
     }
     
 

--- a/modules/aws-idc-integration/iam-roles/main.tf
+++ b/modules/aws-idc-integration/iam-roles/main.tf
@@ -1,6 +1,6 @@
 
 locals {
-  trusted_principals = compact([var.common_fate_aws_account_id, var.common_fate_aws_reader_role_arn])
+  trusted_principals = compact([var.common_fate_aws_account_id, var.common_fate_aws_reader_role_arn, var.common_fate_aws_provisioner_role_arn])
 }
 
 # This policy allows the trusted principlas if one or more are specified else explicit deny

--- a/modules/aws-idc-integration/iam-roles/variables.tf
+++ b/modules/aws-idc-integration/iam-roles/variables.tf
@@ -10,12 +10,18 @@ variable "stage" {
   type        = string
 }
 
+// This has been deprecated in favour of using tag based assume role policies
 variable "common_fate_aws_reader_role_arn" {
+  description = "Deprecated: Use common_fate_aws_account_id instead"
   type = string
+  default = ""
 }
 
+// This has been deprecated in favour of using tag based assume role policies
 variable "common_fate_aws_provisioner_role_arn" {
+  description = "Deprecated: Use common_fate_aws_account_id instead"
   type = string
+  default = ""
 }
 
 variable "permit_management_account_assignments" {
@@ -35,3 +41,14 @@ variable "permit_provision_permission_sets" {
   default     = false
 }
 
+variable "common_fate_aws_account_id" {
+  description = "The ID or the account where Common Fate is deployed"
+  type        = string
+  default     = "" // Optional to avoid breaking changes, in future we can make this required
+}
+
+variable "assume_role_external_id" {
+  description = "The external id to be used for the IAM policy trust relation"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Makes a non breaking change to the AWS roles module to support trusting the common fate account with external ID