### PR TITLE
add iam:GetRole to provisioner for AWS IAM IDC org root account access

### DIFF
--- a/modules/aws-idc-integration/iam-roles/main.tf
+++ b/modules/aws-idc-integration/iam-roles/main.tf
@@ -168,6 +168,7 @@ resource "aws_iam_policy" "idc_provision_management_account" {
           "iam:AttachRolePolicy",
           "iam:CreateRole",
           "iam:PutRolePolicy",
+          "iam:GetRole",
           "iam:UpdateRole",
           "iam:UpdateRoleDescription",
           "iam:UpdateAssumeRolePolicy",


### PR DESCRIPTION
Extends on the testing in https://github.com/common-fate/terraform-aws-common-fate-deployment/pull/67 to handle an additional edge case we found where Common Fate could fail to provision access if the user already has the Permission Set assigned to them.