### PR TITLE
expose deletion protection variable for RDS database

### DIFF
--- a/.changeset/beige-planets-grin.md
+++ b/.changeset/beige-planets-grin.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Allows RDS deletion protection to be disabled by setting the `database_deletion_protection` to `false`. Deletion protection is enabled by default, but can now be disabled in order to destroy the stack.

--- a/main.tf
+++ b/main.tf
@@ -27,11 +27,12 @@ module "alb" {
 }
 
 module "control_plane_db" {
-  source          = "./modules/database"
-  namespace       = var.namespace
-  stage           = var.stage
-  vpc_id          = module.vpc.vpc_id
-  subnet_group_id = module.vpc.database_subnet_group_id
+  source              = "./modules/database"
+  namespace           = var.namespace
+  stage               = var.stage
+  vpc_id              = module.vpc.vpc_id
+  subnet_group_id     = module.vpc.database_subnet_group_id
+  deletion_protection = var.database_deletion_protection
 }
 
 module "authz_db" {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -30,6 +30,6 @@ resource "aws_db_instance" "pg_db" {
   skip_final_snapshot          = true
   db_subnet_group_name         = var.subnet_group_id
   vpc_security_group_ids       = [aws_security_group.rds_sg.id]
-  deletion_protection          = true
+  deletion_protection          = var.deletion_protection
   performance_insights_enabled = true
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -20,3 +20,9 @@ variable "subnet_group_id" {
   description = "Specifies the ID of the subnet group for deployment."
   type        = string
 }
+
+variable "deletion_protection" {
+  description = "Enables deletion protection for the RDS database."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -282,3 +282,9 @@ variable "one_nat_gateway_per_az" {
   default     = true
   description = "Should be false if you want to provision a single shared NAT Gateway for the deployment."
 }
+
+variable "database_deletion_protection" {
+  description = "Enables deletion protection for the RDS database. For production deployments this should be set to 'true'."
+  default     = true
+  type        = bool
+}


### PR DESCRIPTION
allows the stack to be torn down without manually drifting the TF.