### PR TITLE
fix the nat gateway variable propagation to the 'vpc' module

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -15,6 +15,6 @@ module "vpc" {
   create_database_subnet_group = true
   enable_dns_hostnames         = true
   enable_nat_gateway           = true
-  single_nat_gateway           = false
-  one_nat_gateway_per_az       = true
+  single_nat_gateway           = var.single_nat_gateway
+  one_nat_gateway_per_az       = var.one_nat_gateway_per_az
 }


### PR DESCRIPTION
#74 contained an error where the variable was not wired up to the 'vpc' module.