### PR TITLE
provisioner_task_role_name fix 

### DIFF
--- a/.changeset/beige-planets-grin.md
+++ b/.changeset/beige-planets-grin.md
@@ -1,5 +1,0 @@
----
-"@common-fate/terraform-aws-common-fate-deployment": minor
----
-
-Allows RDS deletion protection to be disabled by setting the `database_deletion_protection` to `false`. Deletion protection is enabled by default, but can now be disabled in order to destroy the stack.

--- a/.changeset/beige-planets-grin1.md
+++ b/.changeset/beige-planets-grin1.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Fixed task_role_name output for provisioner module

--- a/modules/provisioner/outputs.tf
+++ b/modules/provisioner/outputs.tf
@@ -12,7 +12,7 @@ output "task_role_arn" {
 }
 
 output "task_role_name" {
-  description = "The ARN of the IAM role assumed by the task"
-  value       = aws_iam_role.provisioner_ecs_task_role.arn
+  description = "The name of the IAM role assumed by the task"
+  value       = aws_iam_role.provisioner_ecs_task_role.name
 }
 


### PR DESCRIPTION
`provisioner_task_role_arn` and `provisioner_task_role_name` both pointed to the arn. Fixed the `provisioner_task_role_name` to point to the name 