### PR TITLE
updates logout redirect url to a valid url

### DIFF
--- a/.changeset/four-pets-walk.md
+++ b/.changeset/four-pets-walk.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Update logout redirect URL

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -60,7 +60,7 @@ resource "aws_cognito_user_pool_client" "web-app-client" {
   generate_secret                      = false
   allowed_oauth_scopes                 = ["openid", "profile", "email"]
   callback_urls                        = ["${var.app_url}/auth/callback"]
-  logout_urls                          = ["${var.app_url}/logout"]
+  logout_urls                          = ["${var.app_url}/access"]
   depends_on                           = [aws_cognito_identity_provider.saml_idp]
 }
 


### PR DESCRIPTION
Updates logout url to existing page. Previously `/logout` didn't exist and returned a 404