### PR TITLE
add top-level variables to improve BYOVPC support

### DIFF
--- a/.changeset/pretty-lobsters-argue-2.md
+++ b/.changeset/pretty-lobsters-argue-2.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds `use_internal_load_balancer` variable, which can be used to make the Common Fate load balancer internal.

--- a/.changeset/pretty-lobsters-argue.md
+++ b/.changeset/pretty-lobsters-argue.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds support for top-level BYOVPC variables, making it easier to deploy Common Fate into an existing AWS VPC.

--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,9 @@ module "alb" {
   certificate_arns = [
     var.app_certificate_arn
   ]
-  public_subnet_ids = local.public_subnet_ids
-  vpc_id            = local.vpc_id
+  public_subnet_ids          = local.public_subnet_ids
+  vpc_id                     = local.vpc_id
+  use_internal_load_balancer = var.use_internal_load_balancer
 }
 
 module "control_plane_db" {

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,18 @@ provider "aws" {
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
+locals {
+  vpc_id                   = var.vpc_id != null ? var.vpc_id : module.vpc[0].vpc_id
+  public_subnet_ids        = var.vpc_id != null ? var.public_subnet_ids : module.vpc[0].public_subnet_ids
+  private_subnet_ids       = var.vpc_id != null ? var.private_subnet_ids : module.vpc[0].private_subnet_ids
+  database_subnet_group_id = var.vpc_id != null ? var.database_subnet_group_id : module.vpc[0].database_subnet_group_id
+  ecs_cluster_id           = var.ecs_cluster_id != null ? var.ecs_cluster_id : module.ecs[0].cluster_id
+}
+
+
 
 module "vpc" {
+  count                  = var.vpc_id != null ? 0 : 1
   source                 = "./modules/vpc"
   namespace              = var.namespace
   stage                  = var.stage
@@ -22,16 +32,16 @@ module "alb" {
   certificate_arns = [
     var.app_certificate_arn
   ]
-  public_subnet_ids = module.vpc.public_subnet_ids
-  vpc_id            = module.vpc.vpc_id
+  public_subnet_ids = local.public_subnet_ids
+  vpc_id            = local.vpc_id
 }
 
 module "control_plane_db" {
   source              = "./modules/database"
   namespace           = var.namespace
   stage               = var.stage
-  vpc_id              = module.vpc.vpc_id
-  subnet_group_id     = module.vpc.database_subnet_group_id
+  vpc_id              = local.vpc_id
+  subnet_group_id     = local.database_subnet_group_id
   deletion_protection = var.database_deletion_protection
 }
 
@@ -49,6 +59,7 @@ module "events" {
 }
 
 module "ecs" {
+  count                                 = var.ecs_cluster_id != null ? 0 : 1
   source                                = "terraform-aws-modules/ecs/aws"
   version                               = "~> 4.1.3"
   cluster_name                          = "${var.namespace}-${var.stage}-cluster"
@@ -96,9 +107,9 @@ module "control_plane" {
   slack_client_id                            = var.slack_client_id
   slack_client_secret_ps_arn                 = var.slack_client_secret_ps_arn
   slack_signing_secret_ps_arn                = var.slack_signing_secret_ps_arn
-  subnet_ids                                 = module.vpc.private_subnet_ids
-  vpc_id                                     = module.vpc.vpc_id
-  ecs_cluster_id                             = module.ecs.cluster_id
+  subnet_ids                                 = local.private_subnet_ids
+  vpc_id                                     = local.vpc_id
+  ecs_cluster_id                             = local.ecs_cluster_id
   auth_authority_url                         = module.cognito.auth_authority_url
   database_host                              = module.control_plane_db.endpoint
   database_user                              = module.control_plane_db.username
@@ -140,15 +151,15 @@ module "web" {
   stage                                   = var.stage
   aws_region                              = var.aws_region
   release_tag                             = var.release_tag
-  subnet_ids                              = module.vpc.private_subnet_ids
-  vpc_id                                  = module.vpc.vpc_id
+  subnet_ids                              = local.private_subnet_ids
+  vpc_id                                  = local.vpc_id
   auth_authority_url                      = module.cognito.auth_authority_url
   auth_cli_client_id                      = module.cognito.cli_client_id
   auth_url                                = module.cognito.auth_url
   auth_web_client_id                      = module.cognito.web_client_id
   logo_url                                = var.logo_url
   team_name                               = var.team_name
-  ecs_cluster_id                          = module.ecs.cluster_id
+  ecs_cluster_id                          = local.ecs_cluster_id
   alb_listener_arn                        = module.alb.listener_arn
   app_url                                 = var.app_url
   auth_issuer                             = module.cognito.auth_issuer
@@ -163,10 +174,10 @@ module "access_handler" {
   aws_region                                = var.aws_region
   eventbus_arn                              = module.events.event_bus_arn
   release_tag                               = var.release_tag
-  subnet_ids                                = module.vpc.private_subnet_ids
-  vpc_id                                    = module.vpc.vpc_id
+  subnet_ids                                = local.private_subnet_ids
+  vpc_id                                    = local.vpc_id
   auth_authority_url                        = module.cognito.auth_authority_url
-  ecs_cluster_id                            = module.ecs.cluster_id
+  ecs_cluster_id                            = local.ecs_cluster_id
   alb_listener_arn                          = module.alb.listener_arn
   auth_issuer                               = module.cognito.auth_issuer
   log_level                                 = var.access_handler_log_level
@@ -187,9 +198,9 @@ module "authz" {
   aws_region                            = var.aws_region
   eventbus_arn                          = module.events.event_bus_arn
   release_tag                           = var.release_tag
-  subnet_ids                            = module.vpc.private_subnet_ids
-  vpc_id                                = module.vpc.vpc_id
-  ecs_cluster_id                        = module.ecs.cluster_id
+  subnet_ids                            = local.private_subnet_ids
+  vpc_id                                = local.vpc_id
+  ecs_cluster_id                        = local.ecs_cluster_id
   alb_listener_arn                      = module.alb.listener_arn
   dynamodb_table_name                   = module.authz_db.dynamodb_table_name
   log_level                             = var.authz_log_level
@@ -214,9 +225,9 @@ module "provisioner" {
   release_tag                       = var.release_tag
   access_handler_sg_id              = module.access_handler.security_group_id
   allow_ingress_from_sg_ids         = [module.control_plane.security_group_id]
-  subnet_ids                        = module.vpc.private_subnet_ids
-  vpc_id                            = module.vpc.vpc_id
-  ecs_cluster_id                    = module.ecs.cluster_id
+  subnet_ids                        = local.private_subnet_ids
+  vpc_id                            = local.vpc_id
+  ecs_cluster_id                    = local.ecs_cluster_id
   provisioner_service_client_id     = module.cognito.provisioner_client_id
   provisioner_service_client_secret = module.cognito.provisioner_client_secret
   auth_issuer                       = module.cognito.auth_issuer
@@ -228,6 +239,4 @@ module "provisioner" {
   entra_config   = var.provisioner_entra_config
   aws_rds_config = var.provisioner_aws_rds_config
   okta_config    = var.provisioner_okta_config
-
-
 }

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,10 @@ locals {
   ecs_cluster_id           = var.ecs_cluster_id != null ? var.ecs_cluster_id : module.ecs[0].cluster_id
 }
 
-
+moved {
+  from = module.vpc
+  to   = module.vpc[0]
+}
 
 module "vpc" {
   count                  = var.vpc_id != null ? 0 : 1
@@ -57,6 +60,11 @@ module "events" {
   source    = "./modules/events"
   namespace = var.namespace
   stage     = var.stage
+}
+
+moved {
+  from = module.ecs
+  to   = module.ecs[0]
 }
 
 module "ecs" {

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "alb_sg" {
 #trivy:ignore:AVD-AWS-0053 
 resource "aws_lb" "main_alb" {
   name                             = "${var.namespace}-${var.stage}-common-fate"
-  internal                         = false
+  internal                         = var.use_internal_load_balancer
   load_balancer_type               = "application"
   security_groups                  = [aws_security_group.alb_sg.id]
   subnets                          = var.public_subnet_ids

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -31,3 +31,8 @@ variable "public_subnet_ids" {
   description = "Lists the subnet IDs for public subnets."
   type        = list(string)
 }
+
+variable "use_internal_load_balancer" {
+  description = "If 'true', the provisioned load balancer will be internal rather than external. Use this when you want to restrict network access to Common Fate to be behind a VPN only."
+  default     = false
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,9 +25,9 @@ output "outputs" {
     provisioner_client_id            = module.cognito.provisioner_client_id
     control_plane_task_role_arn      = module.control_plane.task_role_arn
     access_handler_security_group_id = module.access_handler.security_group_id
-    vpc_id                           = module.vpc.vpc_id
-    private_subnet_ids               = module.vpc.private_subnet_ids
-    ecs_cluster_id                   = module.ecs.cluster_id
+    vpc_id                           = local.vpc_id
+    private_subnet_ids               = local.private_subnet_ids
+    ecs_cluster_id                   = local.ecs_cluster_id
     auth_issuer                      = module.cognito.auth_issuer
     event_bus_log_group_name         = module.events.event_bus_log_group_name
     cognito_user_pool_id             = module.cognito.user_pool_id
@@ -129,19 +129,19 @@ output "access_handler_security_group_id" {
 
 output "vpc_id" {
   description = "The vpc id."
-  value       = module.vpc.vpc_id
+  value       = local.vpc_id
 }
 
 
 output "private_subnet_ids" {
   description = "The private subnet id."
-  value       = module.vpc.private_subnet_ids
+  value       = local.private_subnet_ids
 }
 
 
 output "ecs_cluster_id" {
   description = "The ecs id."
-  value       = module.ecs.cluster_id
+  value       = local.ecs_cluster_id
 }
 output "auth_issuer" {
   description = "The auth issuer."

--- a/variables.tf
+++ b/variables.tf
@@ -288,3 +288,39 @@ variable "database_deletion_protection" {
   default     = true
   type        = bool
 }
+
+variable "vpc_id" {
+  description = "For BYO VPC deployments: specifies the ID of the Virtual Private Cloud (VPC) for deployment."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+
+variable "database_subnet_group_id" {
+  description = "For BYO VPC deployments: specifies the ID of the database subnet group for deployment."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "public_subnet_ids" {
+  description = "For BYO VPC deployments: specifies the IDs of the VPC public subnets."
+  type        = list(string)
+  default     = null
+  nullable    = true
+}
+
+variable "private_subnet_ids" {
+  description = "For BYO VPC deployments: specifies the IDs of the VPC private subnets."
+  type        = list(string)
+  default     = null
+  nullable    = true
+}
+
+variable "ecs_cluster_id" {
+  description = "For BYO VPC deployments: specifies the ID of an existing ECS cluster to deploy to."
+  type        = string
+  default     = null
+  nullable    = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -324,3 +324,8 @@ variable "ecs_cluster_id" {
   default     = null
   nullable    = true
 }
+
+variable "use_internal_load_balancer" {
+  description = "If 'true', the provisioned load balancer will be internal rather than external. Use this when you want to restrict network access to Common Fate to be behind a VPN only."
+  default     = false
+}


### PR DESCRIPTION
Previously, our BYOVPC deployment example required deploying each Common Fate submodule individually, e.g:

```hcl
module "alb" {
  source    = "common-fate/common-fate-deployment/aws//modules/alb"
  version   = "1.0.0"
  namespace = var.namespace
  stage     = var.stage
  certificate_arns = [
    var.app_certificate_arn
  ]
  public_subnet_ids = var.public_subnet_ids
  vpc_id            = var.vpc_id
}

module "control_plane_db" {
  source          = "common-fate/common-fate-deployment/aws//modules/database"
  version         = "1.0.0"
  namespace       = var.namespace
  stage           = var.stage
  vpc_id          = var.vpc_id
  subnet_group_id = var.database_subnet_group_id
}

module "authz_db" {
  source    = "common-fate/common-fate-deployment/aws//modules/authz-database"
  version   = "1.0.0"
  namespace = var.namespace
  stage     = var.stage
}

... additional modules
```

This complicates the management of the infrastructure because customers need to ensure each submodule is aligned with the various variables that we're introducing and updating in the stack.

The submodules should be considered an implementation detail, and we should make BYOVPC variables first-class to minimise deployment complexity for customers.

This PR implements this. An example of how this looks is as follows:

```hcl
module "common-fate-deployment" {
  source = "common-fate/common-fate-deployment/aws"

  vpc_id                     = module.vpc.vpc_id
  database_subnet_group_id   = module.vpc.database_subnet_group
  public_subnet_ids          = module.vpc.public_subnets
  private_subnet_ids         = module.vpc.private_subnets

  // ... other variables here
}
```

Additionally this PR adds a top-level variable to use an internal ALB, rather than an external one. This allows customers to deploy Common Fate to a VPC and use a VPN, or other private networking controls, for accessing Common Fate.