### PR TITLE
Use the correct cloudwatch log group for the worker

### DIFF
--- a/.changeset/little-elephants-grab.md
+++ b/.changeset/little-elephants-grab.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Use the correct cloudwatch log group for the Worker service

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -613,7 +613,7 @@ resource "aws_ecs_task_definition" "worker_task" {
       logConfiguration = {
         logDriver = "awslogs",
         options = {
-          "awslogs-group"         = aws_cloudwatch_log_group.control_plane_log_group.name,
+          "awslogs-group"         = aws_cloudwatch_log_group.worker_log_group.name,
           "awslogs-region"        = var.aws_region,
           "awslogs-stream-prefix" = "worker"
         }


### PR DESCRIPTION
The log group was incorrectly configured for the worker which meant that the `cf deployment logs` command would not list any logs for the worker