### PR TITLE
add support for customising web console refresh token validity

### DIFF
--- a/.changeset/neat-parents-jump.md
+++ b/.changeset/neat-parents-jump.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds support for configuring the web console refresh token validity, using the 'web_refresh_token_validity_duration' and 'web_refresh_token_validity_units' variables.

--- a/main.tf
+++ b/main.tf
@@ -81,17 +81,20 @@ module "ecs_base" {
 
 
 module "cognito" {
-  source                             = "./modules/cognito"
-  namespace                          = var.namespace
-  stage                              = var.stage
-  aws_region                         = var.aws_region
-  app_url                            = var.app_url
-  auth_url                           = var.auth_url
-  auth_certificate_arn               = var.auth_certificate_arn
-  saml_metadata_is_file              = var.saml_metadata_is_file
-  saml_metadata_source               = var.saml_metadata_source
-  saml_provider_name                 = var.saml_provider_name
-  web_access_token_validity_duration = var.web_access_token_validity_duration
+  source                              = "./modules/cognito"
+  namespace                           = var.namespace
+  stage                               = var.stage
+  aws_region                          = var.aws_region
+  app_url                             = var.app_url
+  auth_url                            = var.auth_url
+  auth_certificate_arn                = var.auth_certificate_arn
+  saml_metadata_is_file               = var.saml_metadata_is_file
+  saml_metadata_source                = var.saml_metadata_source
+  saml_provider_name                  = var.saml_provider_name
+  web_access_token_validity_duration  = var.web_access_token_validity_duration
+  web_access_token_validity_units     = var.web_access_token_validity_units
+  web_refresh_token_validity_duration = var.web_refresh_token_validity_duration
+  web_refresh_token_validity_units    = var.web_refresh_token_validity_units
 }
 
 

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -63,8 +63,10 @@ resource "aws_cognito_user_pool_client" "web-app-client" {
   logout_urls                          = ["${var.app_url}/logout"]
   depends_on                           = [aws_cognito_identity_provider.saml_idp]
   access_token_validity                = var.web_access_token_validity_duration
+  refresh_token_validity               = var.web_refresh_token_validity_duration
   token_validity_units {
-    access_token = "minutes"
+    access_token  = var.web_access_token_validity_units
+    refresh_token = var.web_refresh_token_validity_units
   }
 }
 

--- a/modules/cognito/variables.tf
+++ b/modules/cognito/variables.tf
@@ -52,8 +52,23 @@ variable "saml_metadata_source" {
 }
 
 variable "web_access_token_validity_duration" {
-  description = "Specifies how long the access token in the web cognito client will be valid for. Unit is in minutes"
+  description = "Specifies how long the access token in the web cognito client will be valid for. Unit is specified in `web_oidc_token_validity_units` and is in minutes by default."
   default     = 10
   type        = number
 }
 
+variable "web_refresh_token_validity_duration" {
+  description = "Specifies how long the refresh token in the web cognito client will be valid for.  Unit is specified in `web_oidc_token_validity_units` and is in days by default."
+  default     = 30
+  type        = number
+}
+
+variable "web_access_token_validity_units" {
+  description = "Specifies the duration unit used for the 'web_access_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "minutes"
+}
+
+variable "web_refresh_token_validity_units" {
+  description = "Specifies the duration unit used for the 'web_access_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "days"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -348,6 +348,22 @@ variable "web_access_token_validity_duration" {
   type        = number
 }
 
+variable "web_refresh_token_validity_duration" {
+  description = "Specifies how long the refresh token in the web cognito client will be valid for.  Unit is specified in `web_oidc_token_validity_units` and is in days by default."
+  default     = 30
+  type        = number
+}
+
+variable "web_access_token_validity_units" {
+  description = "Specifies the duration unit used for the 'web_access_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "minutes"
+}
+
+variable "web_refresh_token_validity_units" {
+  description = "Specifies the duration unit used for the 'web_access_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "days"
+}
+
 variable "worker_image_repository" {
   type        = string
   description = "Docker image repository to use for the Worker image"


### PR DESCRIPTION
Adds support for configuring the web console refresh token validity, using the 'web_refresh_token_validity_duration' and 'web_refresh_token_validity_units' variables.