### PR TITLE
add default AWS RDS encryption for new deployments

### DIFF
--- a/.changeset/lemon-months-smell.md
+++ b/.changeset/lemon-months-smell.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+The AWS RDS instance is now encrypted by default for new Common Fate deployments.

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -32,4 +32,9 @@ resource "aws_db_instance" "pg_db" {
   vpc_security_group_ids       = [aws_security_group.rds_sg.id]
   deletion_protection          = var.deletion_protection
   performance_insights_enabled = true
+  storage_encrypted            = true
+
+  lifecycle {
+    ignore_changes = [storage_encrypted]
+  }
 }


### PR DESCRIPTION
Adds the `storage_encryption` field to the RDS instance.