### PR TITLE
add additional IAM conditions on ECS roles

### DIFF
--- a/.changeset/large-buckets-glow.md
+++ b/.changeset/large-buckets-glow.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Adds additional 'Condition' keys to the IAM roles used by ECS to protect against confused deputy issues.

--- a/main.tf
+++ b/main.tf
@@ -178,6 +178,7 @@ module "web" {
   namespace                               = var.namespace
   stage                                   = var.stage
   aws_region                              = var.aws_region
+  aws_account_id                          = data.aws_caller_identity.current.account_id
   release_tag                             = var.release_tag
   subnet_ids                              = local.private_subnet_ids
   vpc_id                                  = local.vpc_id
@@ -201,6 +202,7 @@ module "access_handler" {
   namespace                                 = var.namespace
   stage                                     = var.stage
   aws_region                                = var.aws_region
+  aws_account_id                            = data.aws_caller_identity.current.account_id
   eventbus_arn                              = module.events.event_bus_arn
   release_tag                               = var.release_tag
   subnet_ids                                = local.private_subnet_ids
@@ -225,6 +227,7 @@ module "authz" {
   namespace                             = var.namespace
   stage                                 = var.stage
   aws_region                            = var.aws_region
+  aws_account_id                        = data.aws_caller_identity.current.account_id
   eventbus_arn                          = module.events.event_bus_arn
   release_tag                           = var.release_tag
   subnet_ids                            = local.private_subnet_ids
@@ -255,6 +258,7 @@ module "provisioner" {
   namespace                         = var.namespace
   stage                             = var.stage
   aws_region                        = var.aws_region
+  aws_account_id                    = data.aws_caller_identity.current.account_id
   release_tag                       = var.release_tag
   access_handler_sg_id              = module.access_handler.security_group_id
   allow_ingress_from_sg_ids         = [module.control_plane.security_group_id]

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -46,6 +46,14 @@ resource "aws_iam_role" "access_handler_ecs_execution_role" {
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
+        }
       }
     ]
   })
@@ -70,6 +78,14 @@ resource "aws_iam_role" "access_handler_ecs_task_role" {
         Effect = "Allow",
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
+        }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
         }
       }
     ]

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -30,6 +30,11 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_account_id" {
+  description = "Determines the AWS account ID for deployment."
+  type        = string
+}
+
 variable "release_tag" {
   description = "Defines the tag for frontend and backend images, typically a git commit hash."
   type        = string

--- a/modules/authz/main.tf
+++ b/modules/authz/main.tf
@@ -65,6 +65,14 @@ resource "aws_iam_role" "authz_ecs_execution_role" {
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
+        }
       }
     ]
   })
@@ -86,6 +94,14 @@ resource "aws_iam_role" "authz_ecs_task_role" {
         Effect = "Allow",
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
+        }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
         }
       }
     ]

--- a/modules/authz/variables.tf
+++ b/modules/authz/variables.tf
@@ -30,6 +30,11 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_account_id" {
+  description = "Determines the AWS account ID for deployment."
+  type        = string
+}
+
 variable "release_tag" {
   description = "Defines the tag for the frontend and backend images, typically a git commit hash."
   type        = string

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -96,6 +96,14 @@ resource "aws_iam_role" "control_plane_ecs_execution_role" {
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
+        }
       }
     ]
   })
@@ -174,6 +182,14 @@ resource "aws_iam_role" "control_plane_ecs_task_role" {
         Effect = "Allow",
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
+        }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
         }
       }
     ]

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -211,6 +211,14 @@ resource "aws_iam_role" "provisioner_ecs_execution_role" {
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
+        }
       }
     ]
   })
@@ -235,6 +243,14 @@ resource "aws_iam_role" "provisioner_ecs_task_role" {
         Effect = "Allow",
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
+        }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
         }
       }
     ]

--- a/modules/provisioner/variables.tf
+++ b/modules/provisioner/variables.tf
@@ -46,6 +46,11 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_account_id" {
+  description = "Determines the AWS account ID for deployment."
+  type        = string
+}
+
 variable "release_tag" {
   description = "Defines the tag for frontend and backend images, typically a git commit hash."
   type        = string

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -39,6 +39,14 @@ resource "aws_iam_role" "web_ecs_execution_role" {
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : "${var.aws_account_id}"
+          }
+        }
       }
     ]
   })

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -61,6 +61,11 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_account_id" {
+  description = "Determines the AWS account ID for deployment."
+  type        = string
+}
+
 variable "auth_url" {
   description = "Specifies the authentication domain (e.g., 'https://auth.mydomain.com')."
   type        = string


### PR DESCRIPTION
Adds the following IAM conditions to ECS roles:

```hcl
Condition = {
          ArnLike = {
            "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:*"
          }
          StringEquals = {
            "aws:SourceAccount" : "${var.aws_account_id}"
          }
        }
```