### PR TITLE
Adds a new listener rule to redirect some RPCs to the control plane

### DIFF
--- a/.changeset/chilly-mails-hug.md
+++ b/.changeset/chilly-mails-hug.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Redirect access service preview APIs to the control plane

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -802,9 +802,9 @@ resource "aws_lb_listener_rule" "service_rule_access_redirect_query" {
   condition {
     path_pattern {
       values = [
-        "commonfate.access.v1alpha1.AccessService/QueryAvailabilities",
-        "commonfate.access.v1alpha1.AccessService/QueryEntitlements",
-        "commonfate.access.v1alpha1.AccessService/QueryApprovers",
+        "/commonfate.access.v1alpha1.AccessService/QueryAvailabilities",
+        "/commonfate.access.v1alpha1.AccessService/QueryEntitlements",
+        "/commonfate.access.v1alpha1.AccessService/QueryApprovers",
       ]
     }
   }
@@ -828,8 +828,8 @@ resource "aws_lb_listener_rule" "service_rule_access_redirect_preview" {
   condition {
     path_pattern {
       values = [
-        "commonfate.access.v1alpha1.AccessService/PreviewUserAccess",
-        "commonfate.access.v1alpha1.AccessService/PreviewEntitlementAccess"
+        "/commonfate.access.v1alpha1.AccessService/PreviewUserAccess",
+        "/commonfate.access.v1alpha1.AccessService/PreviewEntitlementAccess"
       ]
     }
   }

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -756,7 +756,36 @@ resource "aws_lb_listener_rule" "service_rule" {
   }
   condition {
     path_pattern {
-      values = ["/commonfate.control*", "/api/*", "/commonfate.leastprivilege*"]
+      values = ["/commonfate.control*", "/api/*", "/commonfate.leastprivilege*"
+      ]
+    }
+  }
+}
+
+
+// This rule temporarily redirects some access service RPCs to the control plane
+resource "aws_lb_listener_rule" "service_rule_access_redirect" {
+  listener_arn = var.alb_listener_arn
+  priority     = 55 // lower that the access handler
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.control_plane_tg.arn
+  }
+
+  condition {
+    host_header {
+      values = [replace(var.app_url, "https://", "")]
+    }
+  }
+  condition {
+    path_pattern {
+      values = [
+        "commonfate.access.v1alpha1.AccessService/QueryAvailabilities",
+        "commonfate.access.v1alpha1.AccessService/QueryEntitlements",
+        "commonfate.access.v1alpha1.AccessService/QueryApprovers",
+        "commonfate.access.v1alpha1.AccessService/PreviewUserAccess",
+        "commonfate.access.v1alpha1.AccessService/PreviewEntitlementAccess"
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR adds an extra listener rule that preceeds the access handler rule in priority and directs preview APIs to the control plane