### PR TITLE
Propagate the namespace, stage, and ecs_opentelemetry_collector_log_retention_in_days variables to the ecs_base module

### DIFF
--- a/.changeset/eight-socks-repeat.md
+++ b/.changeset/eight-socks-repeat.md
@@ -2,4 +2,4 @@
 "@common-fate/terraform-aws-common-fate-deployment": patch
 ---
 
-Fix an issue where the `namespace` and `stage` variables are not propagated to the ecs_base module.
+Fix an issue where the `namespace`, `stage`, and `log_retention_in_days` variables were not propagated to the `ecs_base` module.

--- a/.changeset/eight-socks-repeat.md
+++ b/.changeset/eight-socks-repeat.md
@@ -2,4 +2,4 @@
 "@common-fate/terraform-aws-common-fate-deployment": patch
 ---
 
-Fix an issue where the namespace and stage is not propagated to the ecs_base module.
+Fix an issue where the `namespace` and `stage` variables are not propagated to the ecs_base module.

--- a/.changeset/eight-socks-repeat.md
+++ b/.changeset/eight-socks-repeat.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fix an issue where the namespace and stage is not propagated to the ecs_base module.

--- a/main.tf
+++ b/main.tf
@@ -76,9 +76,10 @@ module "ecs" {
 }
 
 module "ecs_base" {
-  source    = "./modules/ecs-base"
-  namespace = var.namespace
-  stage     = var.stage
+  source                = "./modules/ecs-base"
+  namespace             = var.namespace
+  stage                 = var.stage
+  log_retention_in_days = var.ecs_opentelemetry_collector_log_retention_in_days
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,9 @@ module "ecs" {
 }
 
 module "ecs_base" {
-  source = "./modules/ecs-base"
+  source    = "./modules/ecs-base"
+  namespace = var.namespace
+  stage     = var.stage
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,12 @@ variable "additional_cors_allowed_origins" {
   description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."
 }
 
+variable "ecs_opentelemetry_collector_log_retention_in_days" {
+  description = "Specifies the retention period for the ECS OpenTelemetry Collector CloudWatch Log Group."
+  default     = 365
+  type        = number
+}
+
 
 variable "provisioner_aws_idc_config" {
   description = <<EOF


### PR DESCRIPTION
Fix an issue where the `namespace`, `stage`, and `log_retention` variables are not propagated to the ecs_base module.
