### PR TITLE
[CF-3045] enable multi_az for RDS database

### DIFF
--- a/.changeset/plenty-roses-laugh.md
+++ b/.changeset/plenty-roses-laugh.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Add variable to allow for Multi-AZ on RDS database

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "control_plane_db" {
   deletion_protection      = var.database_deletion_protection
   rds_db_retention_period  = var.rds_db_retention_period
   restore_to_point_in_time = var.restore_to_point_in_time
+  rds_multi_az                 = var.rds_multi_az
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ module "control_plane_db" {
   deletion_protection      = var.database_deletion_protection
   rds_db_retention_period  = var.rds_db_retention_period
   restore_to_point_in_time = var.restore_to_point_in_time
-  rds_multi_az                 = var.rds_multi_az
+  rds_multi_az             = var.rds_multi_az
 }
 
 

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -34,6 +34,7 @@ resource "aws_db_instance" "pg_db" {
   performance_insights_enabled = true
   storage_encrypted            = true
   backup_retention_period      = var.rds_db_retention_period
+  multi_az                     = true
 
   dynamic "restore_to_point_in_time" {
     for_each = var.restore_to_point_in_time != null ? [1] : []

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -34,7 +34,7 @@ resource "aws_db_instance" "pg_db" {
   performance_insights_enabled = true
   storage_encrypted            = true
   backup_retention_period      = var.rds_db_retention_period
-  multi_az                     = true
+  multi_az                     = var.rds_multi_az
 
   dynamic "restore_to_point_in_time" {
     for_each = var.restore_to_point_in_time != null ? [1] : []

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -48,3 +48,9 @@ variable "restore_to_point_in_time" {
   )
   default = null
 }
+
+variable "rds_multi_az" {
+  description = "Enables RDS database to be deployed across multiple Availability Zones"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -457,3 +457,8 @@ variable "dynamodb_restore_to_latest_time" {
   default     = null
 }
 
+variable "rds_multi_az" {
+  description = "Enables RDS database to be deployed across multiple Availability Zones"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This PR ensures that our RDS database can be deployed to multi AZ instead of single AZ

Testing evidence:
```
Terraform will perform the following actions:

  # module.aws_rds.module.control_plane_db.aws_db_instance.pg_db will be updated in-place
  ~ resource "aws_db_instance" "pg_db" {
        id                                    = "db-BL3MICOLOGCWSTWJ4LHXKN7B7Y"
      ~ multi_az                              = false -> true
        tags                                  = {}
        # (53 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

![image](https://github.com/common-fate/terraform-aws-common-fate-deployment/assets/70191007/e6b06ad1-f129-4908-b8b8-12ec1e0185d0)
