### PR TITLE
add alb rule to allow new granted service

### DIFF
--- a/.changeset/metal-moles-sin.md
+++ b/.changeset/metal-moles-sin.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+update alb rule to allow from granted service

--- a/.changeset/metal-moles-sin.md
+++ b/.changeset/metal-moles-sin.md
@@ -2,4 +2,4 @@
 "@common-fate/terraform-aws-common-fate-deployment": patch
 ---
 
-update alb rule to allow from granted service
+For BYOC customers: the Common Fate Control plane now serves the Granted Profile Registry API. We've updated the load balancer rules to reflect this.

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -788,7 +788,7 @@ resource "aws_lb_listener_rule" "service_rule" {
   }
   condition {
     path_pattern {
-      values = ["/commonfate.control*", "/api/*", "/commonfate.leastprivilege*"
+      values = ["/commonfate.control*", "/api/*", "/commonfate.leastprivilege*", "/granted*"
       ]
     }
   }


### PR DESCRIPTION
New granted service was added in https://github.com/common-fate/sdk/pull/103

Currently not working in production due to not having a alb rule allowing it to be called