### PR TITLE
add rds_apply_immediately variable

### DIFF
--- a/.changeset/sweet-papayas-enjoy.md
+++ b/.changeset/sweet-papayas-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds 'rds_apply_immediately' variable to immediately apply RDS changes. Set to 'true' by default.

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ module "control_plane_db" {
   rds_db_retention_period  = var.rds_db_retention_period
   restore_to_point_in_time = var.restore_to_point_in_time
   rds_multi_az             = var.rds_multi_az
+  apply_immediately        = var.rds_apply_immediately
 }
 
 

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -35,6 +35,7 @@ resource "aws_db_instance" "pg_db" {
   storage_encrypted            = true
   backup_retention_period      = var.rds_db_retention_period
   multi_az                     = var.rds_multi_az
+  apply_immediately            = var.apply_immediately
 
   dynamic "restore_to_point_in_time" {
     for_each = var.restore_to_point_in_time != null ? [1] : []

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -54,3 +54,10 @@ variable "rds_multi_az" {
   type        = bool
   default     = true
 }
+
+
+variable "apply_immediately" {
+  description = "Apply RDS changes immediately."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -462,3 +462,9 @@ variable "rds_multi_az" {
   type        = bool
   default     = true
 }
+
+variable "rds_apply_immediately" {
+  description = "Apply RDS changes immediately."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Adds `rds_apply_immediately` to allow the upgrade from single to multi-AZ RDS databases to occur during a deployment, rather than waiting for a maintenance window. We currently don't configure maintenance windows in the TF stack, so the previous behaviour may catch users by surprise.