### PR TITLE
remove graphql from authz module

### DIFF
--- a/.changeset/giant-taxis-kneel.md
+++ b/.changeset/giant-taxis-kneel.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Removes the networking configuration for the Graphql API which has been removed from the authz service.


### PR DESCRIPTION
Removes the networking associated with the graphql API which has been removed from the authz service.