### PR TITLE
Add support for Managed Monitoring configuration

### DIFF
--- a/.changeset/curvy-meals-thank.md
+++ b/.changeset/curvy-meals-thank.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds a dead-letter queue to the event handler SQS queue.

--- a/.changeset/seven-students-rule.md
+++ b/.changeset/seven-students-rule.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds support for Managed Monitoring. When enabled, a Common Fate deployment will emit OpenTelemetry events to our centralised OpenTelemetry collector, allowing the Common Fate team to diagnose performance issues and proactively detect errors in your deployment. No identifiable information is included in the OpenTelemetry events.

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,9 @@ data "aws_arn" "licence_key" {
 
 data "aws_ssm_parameter" "licence_key" {
   count = var.licence_key_ps_arn != null ? 1 : 0
-  name  = data.aws_arn.licence_key[0].resource
+  // the parameter resource is e.g. 'parameter/common-fate/prod/licence-key',
+  // but we need '/common-fate/prod/licence-key' here.
+  name = trimprefix(data.aws_arn.licence_key[0].resource, "parameter")
 }
 
 module "vpc" {

--- a/main.tf
+++ b/main.tf
@@ -23,13 +23,13 @@ locals {
 }
 
 data "aws_arn" "licence_key" {
-  for_each = var.licence_key_ps_arn != null ? [1] : []
-  arn      = var.licence_key_ps_arn
+  count = var.licence_key_ps_arn != null ? 1 : 0
+  arn   = var.licence_key_ps_arn
 }
 
 data "aws_ssm_parameter" "licence_key" {
-  for_each = var.licence_key_ps_arn != null ? [1] : []
-  name     = data.aws_arn.licence_key[0].resource
+  count = var.licence_key_ps_arn != null ? 1 : 0
+  name  = data.aws_arn.licence_key[0].resource
 }
 
 module "vpc" {

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -274,6 +274,34 @@ resource "aws_ecs_task_definition" "access_handler_task" {
           name  = "CF_EVAL_SINK_AWS_S3_BUCKET",
           value = var.authz_eval_bucket_name
         },
+        {
+          name  = "CF_LICENCE_KEY",
+          value = var.licence_key
+        },
+        {
+          name  = "CF_FACTORY_BASE_URL",
+          value = var.factory_base_url
+        },
+        {
+          name  = "CF_FACTORY_OIDC_ISSUER",
+          value = var.factory_oidc_issuer
+        },
+        {
+          name  = "CF_MONITORING_LOCAL_ENABLED",
+          value = var.xray_monitoring_enabled ? "true" : "false"
+        },
+        {
+          name  = "CF_MONITORING_MANAGED_ENABLED",
+          value = var.managed_monitoring_enabled ? "true" : "false"
+        },
+        {
+          name  = "CF_MONITORING_MANAGED_ENDPOINT",
+          value = var.managed_monitoring_endpoint
+        },
+        {
+          name  = "CF_DEPLOYMENT_NAME",
+          value = var.stage
+        },
       ],
       secrets = [
         {

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -185,3 +185,38 @@ variable "authz_eval_bucket_arn" {
   type        = string
   description = "ARN of authorization evaluation bucket"
 }
+
+variable "licence_key" {
+  description = "The Common Fate licence key."
+  type        = string
+}
+
+variable "xray_monitoring_enabled" {
+  description = "If enabled, writes OpenTelemetry monitoring events to AWS X-Ray."
+  type        = bool
+  default     = true
+}
+
+variable "managed_monitoring_enabled" {
+  description = "Enables Managed Monitoring for the deployment."
+  type        = bool
+  default     = false
+}
+
+variable "managed_monitoring_endpoint" {
+  description = "The Managed Monitoring OpenTelemetry endpoint"
+  type        = string
+  default     = "https://otel.commonfate.io"
+}
+
+variable "factory_base_url" {
+  description = "The Common Fate Factory API Base URL"
+  type        = string
+  default     = "https://factory.commonfate.io"
+}
+
+variable "factory_oidc_issuer" {
+  description = "The Common Fate Factory OIDC Issuer"
+  type        = string
+  default     = "https://factory.commonfate.io"
+}

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -207,7 +207,7 @@ variable "managed_monitoring_enabled" {
 variable "managed_monitoring_endpoint" {
   description = "The Managed Monitoring OpenTelemetry endpoint"
   type        = string
-  default     = "https://otel.commonfate.io"
+  default     = "otel.commonfate.io"
 }
 
 variable "factory_base_url" {

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -574,6 +574,34 @@ locals {
       name  = "CF_EVAL_SINK_TYPE",
       value = "aws"
     },
+    {
+      name  = "CF_LICENCE_KEY",
+      value = var.licence_key
+    },
+    {
+      name  = "CF_FACTORY_BASE_URL",
+      value = var.factory_base_url
+    },
+    {
+      name  = "CF_FACTORY_OIDC_ISSUER",
+      value = var.factory_oidc_issuer
+    },
+    {
+      name  = "CF_MONITORING_LOCAL_ENABLED",
+      value = var.xray_monitoring_enabled ? "true" : "false"
+    },
+    {
+      name  = "CF_MONITORING_MANAGED_ENABLED",
+      value = var.managed_monitoring_enabled ? "true" : "false"
+    },
+    {
+      name  = "CF_MONITORING_MANAGED_ENDPOINT",
+      value = var.managed_monitoring_endpoint
+    },
+    {
+      name  = "CF_DEPLOYMENT_NAME",
+      value = var.stage
+    },
   ]
 
   // Only add these secrets if their values are provided
@@ -600,10 +628,6 @@ locals {
         name = "CF_PG_PASSWORD",
         // the password key is extracted from the json that is stored in secrets manager so that we don't need to decode it in the go server
         valueFrom = "${var.database_secret_sm_arn}:password::"
-      },
-      {
-        name      = "CF_LICENCE_KEY",
-        valueFrom = var.licence_key_ps_arn
       },
 
   ])

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -343,7 +343,7 @@ variable "managed_monitoring_enabled" {
 variable "managed_monitoring_endpoint" {
   description = "The Managed Monitoring OpenTelemetry endpoint"
   type        = string
-  default     = "https://otel.commonfate.io"
+  default     = "otel.commonfate.io"
 }
 
 variable "factory_base_url" {

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -153,10 +153,12 @@ variable "alb_listener_arn" {
   description = "Specifies the Amazon Load Balancer (ALB) listener ARN."
   type        = string
 }
-variable "licence_key_ps_arn" {
-  description = "The AWS Parameter Store ARN for the license key."
+
+variable "licence_key" {
+  description = "The Common Fate licence key."
   type        = string
 }
+
 variable "log_retention_in_days" {
   description = "Specifies the cloudwatch log retention period."
   default     = 365
@@ -325,3 +327,32 @@ variable "access_handler_service_connect_address" {
   description = "the internal address assigned to the access handler service by AWS ECS service connect"
 }
 
+variable "xray_monitoring_enabled" {
+  description = "If enabled, writes OpenTelemetry monitoring events to AWS X-Ray."
+  type        = bool
+  default     = true
+}
+
+variable "managed_monitoring_enabled" {
+  description = "Enables Managed Monitoring for the deployment."
+  type        = bool
+  default     = false
+}
+
+variable "managed_monitoring_endpoint" {
+  description = "The Managed Monitoring OpenTelemetry endpoint"
+  type        = string
+  default     = "https://otel.commonfate.io"
+}
+
+variable "factory_base_url" {
+  description = "The Common Fate Factory API Base URL"
+  type        = string
+  default     = "https://factory.commonfate.io"
+}
+
+variable "factory_oidc_issuer" {
+  description = "The Common Fate Factory OIDC Issuer"
+  type        = string
+  default     = "https://factory.commonfate.io"
+}

--- a/modules/events/main.tf
+++ b/modules/events/main.tf
@@ -17,7 +17,8 @@ resource "aws_sqs_queue" "event_queue" {
 }
 
 resource "aws_sqs_queue" "event_queue_deadletter" {
-  name = "${var.namespace}-${var.stage}-event-deadletter"
+  name                    = "${var.namespace}-${var.stage}-event-deadletter"
+  sqs_managed_sse_enabled = true
 }
 
 resource "aws_sqs_queue_redrive_allow_policy" "event_queue_redrive_allow_policy" {

--- a/modules/events/main.tf
+++ b/modules/events/main.tf
@@ -11,7 +11,7 @@ resource "aws_sqs_queue" "event_queue" {
   name                    = "${var.namespace}-${var.stage}-event-queue"
   sqs_managed_sse_enabled = true
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
+    deadLetterTargetArn = aws_sqs_queue.event_queue_deadletter.arn
     maxReceiveCount     = 3
   })
 }

--- a/modules/events/main.tf
+++ b/modules/events/main.tf
@@ -8,10 +8,27 @@ resource "aws_cloudwatch_event_bus" "event_bus" {
 
 
 resource "aws_sqs_queue" "event_queue" {
-  name = "${var.namespace}-${var.stage}-event-queue"
+  name                    = "${var.namespace}-${var.stage}-event-queue"
   sqs_managed_sse_enabled = true
-  # Additional configurations like redrive policy can be added here
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
+    maxReceiveCount     = 3
+  })
 }
+
+resource "aws_sqs_queue" "event_queue_deadletter" {
+  name = "${var.namespace}-${var.stage}-event-deadletter"
+}
+
+resource "aws_sqs_queue_redrive_allow_policy" "event_queue_redrive_allow_policy" {
+  queue_url = aws_sqs_queue.event_queue.id
+
+  redrive_allow_policy = jsonencode({
+    redrivePermission = "byQueue",
+    sourceQueueArns   = [aws_sqs_queue.event_queue.arn]
+  })
+}
+
 resource "aws_cloudwatch_event_rule" "to_sqs_rule" {
   name           = "${var.namespace}-${var.stage}-to-sqs-rule"
   description    = "Route events to SQS queue"
@@ -66,7 +83,7 @@ resource "aws_cloudwatch_log_resource_policy" "events_policy" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": [ 
+        "Service": [
           "events.amazonaws.com",
           "delivery.logs.amazonaws.com"
           ]
@@ -84,7 +101,7 @@ resource "aws_cloudwatch_log_resource_policy" "events_policy" {
     }
   ]
 }
-POLICY  
+POLICY
 }
 
 #Create a new Event Rule
@@ -104,4 +121,3 @@ resource "aws_cloudwatch_event_target" "cw_logs_target" {
   event_bus_name = aws_cloudwatch_event_bus.event_bus.name
   target_id      = "SendToCloudwatch"
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -491,7 +491,7 @@ variable "managed_monitoring_enabled" {
 variable "managed_monitoring_endpoint" {
   description = "The Managed Monitoring OpenTelemetry endpoint"
   type        = string
-  default     = "https://otel.commonfate.io"
+  default     = "otel.commonfate.io"
 }
 
 variable "factory_base_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -129,9 +129,14 @@ variable "scim_token_ps_arn" {
 variable "licence_key_ps_arn" {
   description = "The AWS Parameter Store ARN for the license key."
   type        = string
+  nullable    = true
 }
 
-
+variable "licence_key" {
+  description = "The Common Fate licence key."
+  type        = string
+  nullable    = true
+}
 
 variable "access_handler_log_level" {
   description = "Log level for Access Handler service"
@@ -467,4 +472,34 @@ variable "rds_apply_immediately" {
   description = "Apply RDS changes immediately."
   type        = bool
   default     = true
+}
+
+variable "xray_monitoring_enabled" {
+  description = "If enabled, writes OpenTelemetry monitoring events to AWS X-Ray."
+  type        = bool
+  default     = true
+}
+
+variable "managed_monitoring_enabled" {
+  description = "Enables Managed Monitoring for the deployment."
+  type        = bool
+  default     = false
+}
+
+variable "managed_monitoring_endpoint" {
+  description = "The Managed Monitoring OpenTelemetry endpoint"
+  type        = string
+  default     = "https://otel.commonfate.io"
+}
+
+variable "factory_base_url" {
+  description = "The Common Fate Factory API Base URL"
+  type        = string
+  default     = "https://factory.commonfate.io"
+}
+
+variable "factory_oidc_issuer" {
+  description = "The Common Fate Factory OIDC Issuer"
+  type        = string
+  default     = "https://factory.commonfate.io"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,7 @@ variable "licence_key" {
   description = "The Common Fate licence key."
   type        = string
   nullable    = true
+  default     = null
 }
 
 variable "access_handler_log_level" {

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,7 @@ variable "licence_key_ps_arn" {
   description = "The AWS Parameter Store ARN for the license key."
   type        = string
   nullable    = true
+  default     = null
 }
 
 variable "licence_key" {


### PR DESCRIPTION
Allows configuring a Common Fate deployment to emit tracing events to https://otel.commonfate.io.

Also allows providing a licence key as a string, rather than creating it outside of the stack. This makes initial deployment simpler as there is no initial bootstrapping step required.

Adds a dead-letter queue to the SQS events queue. In testing the tracing implementation I found that invalid Slack channel IDs could cause events to be retried indefinitely.