### PR TITLE
Enable embedded authorization by default

### DIFF
--- a/.changeset/thin-bears-rhyme.md
+++ b/.changeset/thin-bears-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Enable embedded authorization by default

--- a/variables.tf
+++ b/variables.tf
@@ -524,6 +524,6 @@ variable "factory_oidc_issuer" {
 
 variable "unstable_feature_embedded_authorizations" {
   type        = bool
-  default     = false
+  default     = true
   description = "Opt-in to enable Embedded Authorization (in early access). This variable will be removed once the feature is released."
 }


### PR DESCRIPTION
Enable the embedded authorization feature by default, leaving it in for one more release so that teams can switch back if required without needing to roll back their deployment