### PR TITLE
add variable to allow database migrations to be disabled

### DIFF
--- a/.changeset/nice-mugs-scream.md
+++ b/.changeset/nice-mugs-scream.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Allow disabling automatic database migrations using the `database_auto_migrate` variable when the Control Plane container starts.

--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,7 @@ module "control_plane" {
   factory_base_url                           = var.factory_base_url
   factory_oidc_issuer                        = var.factory_oidc_issuer
   unstable_feature_embedded_authorizations   = var.unstable_feature_embedded_authorizations
+  database_auto_migrate                      = var.database_auto_migrate
 }
 
 

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -434,6 +434,10 @@ locals {
       name  = "CF_PG_SSLMode",
       value = "require"
     },
+    {
+      name  = "CF_DATABASE_AUTO_MIGRATE",
+      value = var.database_auto_migrate ? "true" : "false"
+    },
 
     {
       name  = "CF_CONTROL_PLANE_SERVICE_OIDC_CLIENT_ID",

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -363,3 +363,9 @@ variable "unstable_feature_embedded_authorizations" {
   default     = false
   description = "Opt-in to enable Embedded Authorization (in early access). This variable will be removed once the feature is released."
 }
+
+variable "database_auto_migrate" {
+  type        = bool
+  default     = true
+  description = "Whether to run database migrations automatically when the Control Plane service starts. If rolling back to a previous release after a migration has run, set this to `false`."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -527,3 +527,10 @@ variable "unstable_feature_embedded_authorizations" {
   default     = true
   description = "Opt-in to enable Embedded Authorization (in early access). This variable will be removed once the feature is released."
 }
+
+
+variable "database_auto_migrate" {
+  type        = bool
+  default     = true
+  description = "Whether to run database migrations automatically when the Control Plane service starts. If rolling back to a previous release after a migration has run, set this to `false`."
+}


### PR DESCRIPTION
Adds a variable to allow database migrations to be disabled - can be used when rolling back to a previous release after migrations have already run.