### PR TITLE
add family name and given name attributes to sso config

### DIFF
--- a/.changeset/tidy-apples-sort.md
+++ b/.changeset/tidy-apples-sort.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Adds given name and family name SAML attributes to client

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -21,7 +21,9 @@ resource "aws_cognito_identity_provider" "saml_idp" {
   provider_type = "SAML"
 
   attribute_mapping = {
-    email = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+    email = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+    family_name = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/familyname",
+    given_name = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
   }
 
   provider_details = var.saml_metadata_is_file ? {


### PR DESCRIPTION
Adds the family name and given name attribute mappings.

This might will need to be tested to check that this doesn't break other sso saml integration. Or if we need to update all of the other docs to include mappings for these.