### PR TITLE
Release app version v3.13.2

### DIFF
--- a/.changeset/dry-mangos-deliver.md
+++ b/.changeset/dry-mangos-deliver.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fix an issue where account name whitespace was not properly removed when using Common Fate as a Granted Profile Registry backend.

--- a/.changeset/six-dogs-happen.md
+++ b/.changeset/six-dogs-happen.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fix an issue preventing Grants from being migrated to the new Common Fate internal storage backend.

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "aws_region" {
 variable "release_tag" {
   description = "Override the application release tag to be used in the deployment. As of module version v1.13.0, application versions are bundled into the Terraform module, and so in most cases you should not override this."
   type        = string
-  default     = "v3.13.1"
+  default     = "v3.13.2"
 }
 
 variable "app_certificate_arn" {


### PR DESCRIPTION
Includes fixes:

- Fix an issue where account name whitespace was not properly removed when using Common Fate as a Granted Profile Registry backend.
- Fix an issue preventing Grants from being migrated to the new Common Fate internal storage backend.