### PR TITLE
Fix read-only client output references

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,7 +22,7 @@ output "outputs" {
     web_client_id                    = module.cognito.web_client_id
     cli_client_id                    = module.cognito.cli_client_id
     terraform_client_id              = module.cognito.terraform_client_id
-    read_only_client_id              = aws_cognito_user_pool_client.read_only_client.id
+    read_only_client_id              = module.cognito.read_only_client_id
     provisioner_client_id            = module.cognito.provisioner_client_id
     control_plane_task_role_arn      = module.control_plane.task_role_arn
     access_handler_security_group_id = module.access_handler.security_group_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -104,14 +104,21 @@ output "terraform_client_id" {
   description = "terraform client id"
   value       = module.cognito.terraform_client_id
 }
-output "read_only_client_id" {
-  description = "The client ID with read only API access."
-  value       = aws_cognito_user_pool_client.read_only_client.id
-}
 
 output "terraform_client_secret" {
   description = "terraform client secret"
   value       = module.cognito.terraform_client_secret
+  sensitive   = true
+}
+
+output "read_only_client_id" {
+  description = "The client ID with read only API access."
+  value       = module.cognito.read_only_client_id
+}
+
+output "read_only_client_secret" {
+  description = "The client secret with read only API access"
+  value       = module.cognito.read_only_client_id
   sensitive   = true
 }
 


### PR DESCRIPTION
They weren't correctly copied to the main module.
