### PR TITLE
Use HTTP/2 for Control Plane policy endpoints

### DIFF
--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -921,10 +921,6 @@ resource "aws_lb_listener_rule" "service_rule_access_redirect_preview" {
 resource "aws_lb_listener_rule" "service_rule_access_redirect_policyset" {
   listener_arn = var.alb_listener_arn
   priority     = 57 // lower than authz
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.control_plane_tg.arn
-  }
 
   action {
     type             = "forward"

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -787,7 +787,7 @@ resource "aws_lb_target_group" "control_plane_tg" {
 }
 
 resource "aws_lb_target_group" "control_plane_tg_http2" {
-  name             = "${var.namespace}-${var.stage}-control-plane-http2"
+  name             = "${var.namespace}-${var.stage}-cp-http2" // ideally would be 'control-plane-http2', but there is a 32 char limit.
   port             = 8080
   protocol         = "HTTP"
   protocol_version = "HTTP2"

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -920,10 +920,15 @@ resource "aws_lb_listener_rule" "service_rule_access_redirect_preview" {
 
 resource "aws_lb_listener_rule" "service_rule_access_redirect_policyset" {
   listener_arn = var.alb_listener_arn
-  priority     = 57 // lower that authz
+  priority     = 57 // lower than authz
   action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.control_plane_tg.arn
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.control_plane_tg_http2.arn
   }
 
   condition {
@@ -940,7 +945,6 @@ resource "aws_lb_listener_rule" "service_rule_access_redirect_policyset" {
     }
   }
 }
-
 
 
 resource "aws_ecs_service" "worker_service" {

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -785,6 +785,20 @@ resource "aws_lb_target_group" "control_plane_tg" {
     path    = "/health"
   }
 }
+
+resource "aws_lb_target_group" "control_plane_tg_http2" {
+  name             = "${var.namespace}-${var.stage}-control-plane-http2"
+  port             = 8080
+  protocol         = "HTTP"
+  protocol_version = "HTTP2"
+  vpc_id           = var.vpc_id
+  target_type      = "ip"
+  health_check {
+    enabled = true
+    path    = "/health"
+  }
+}
+
 resource "aws_ecs_service" "control_plane_service" {
   name            = "${var.namespace}-${var.stage}-control-plane"
   cluster         = var.ecs_cluster_id
@@ -819,6 +833,12 @@ resource "aws_ecs_service" "control_plane_service" {
 
   load_balancer {
     target_group_arn = aws_lb_target_group.control_plane_tg.arn
+    container_name   = "control-plane-container"
+    container_port   = 8080
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.control_plane_tg_http2.arn
     container_name   = "control-plane-container"
     container_port   = 8080
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,7 +22,7 @@ output "outputs" {
     web_client_id                    = module.cognito.web_client_id
     cli_client_id                    = module.cognito.cli_client_id
     terraform_client_id              = module.cognito.terraform_client_id
-    read_only_client_id              = aws_cognito_user_pool_client.read_only_client.id
+    read_only_client_id              = module.cognito.read_only_client_id
     provisioner_client_id            = module.cognito.provisioner_client_id
     control_plane_task_role_arn      = module.control_plane.task_role_arn
     access_handler_security_group_id = module.access_handler.security_group_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -104,14 +104,21 @@ output "terraform_client_id" {
   description = "terraform client id"
   value       = module.cognito.terraform_client_id
 }
-output "read_only_client_id" {
-  description = "The client ID with read only API access."
-  value       = aws_cognito_user_pool_client.read_only_client.id
-}
 
 output "terraform_client_secret" {
   description = "terraform client secret"
   value       = module.cognito.terraform_client_secret
+  sensitive   = true
+}
+
+output "read_only_client_id" {
+  description = "The client ID with read only API access."
+  value       = module.cognito.read_only_client_id
+}
+
+output "read_only_client_secret" {
+  description = "The client secret with read only API access"
+  value       = module.cognito.read_only_client_id
   sensitive   = true
 }
 


### PR DESCRIPTION
We've migrated the Policy API from the Rust-based authz service to the Go Control Plane service. It is now being served by Connect RPC, which is interoperable with GRPC. GRPC interop requires that the Control Plane can accept HTTP/2 traffic. 

The Control Plane ALB target group uses HTTP/1 though, so the GRPC interop does not work.

This causes GRPC clients to stop working - our Validate Cedar Policy GitHub Action is one such example. Here's an example error on the latest prerelease:

![image](https://github.com/common-fate/terraform-aws-common-fate-deployment/assets/17420369/e5153247-6f3d-4d2d-b42b-238cf24a7285)

This PR fixes this issue by introducing a second target group for the Control Plane which uses HTTP/2.

Built on top of #210 so that I could test both at once.
