### PR TITLE
Remove deprecated variables for slack and pagerduty

### DIFF
--- a/.changeset/curly-cars-smell.md
+++ b/.changeset/curly-cars-smell.md
@@ -1,5 +1,5 @@
 ---
-"@common-fate/terraform-aws-common-fate-deployment": major
+"@common-fate/terraform-aws-common-fate-deployment": minor
 ---
 
 Removes the requirement to configure pager_duty_client_id, pager_duty_client_secret_ps_arn, slack_client_id, slack_client_secret_ps_arn, slack_signing_secret_ps_arn variables in the infrastructure layer. This configuration is now pulled directly from the integration config resources in your application configuration.

--- a/.changeset/curly-cars-smell.md
+++ b/.changeset/curly-cars-smell.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+Removes the requirement to configure pager_duty_client_id, pager_duty_client_secret_ps_arn, slack_client_id, slack_client_secret_ps_arn, slack_signing_secret_ps_arn variables in the infrastructure layer. This configuration is now pulled directly from the integration config resources in your application configuration.

--- a/main.tf
+++ b/main.tf
@@ -152,14 +152,9 @@ module "control_plane" {
   eventbus_arn                               = module.events.event_bus_arn
   sqs_queue_arn                              = module.events.sqs_queue_arn
   app_url                                    = var.app_url
-  pager_duty_client_id                       = var.pager_duty_client_id
-  pager_duty_client_secret_ps_arn            = var.pager_duty_client_secret_ps_arn
   release_tag                                = var.release_tag
   scim_source                                = var.scim_source
   scim_token_ps_arn                          = var.scim_token_ps_arn
-  slack_client_id                            = var.slack_client_id
-  slack_client_secret_ps_arn                 = var.slack_client_secret_ps_arn
-  slack_signing_secret_ps_arn                = var.slack_signing_secret_ps_arn
   subnet_ids                                 = local.private_subnet_ids
   vpc_id                                     = local.vpc_id
   ecs_cluster_id                             = local.ecs_cluster_id

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -385,14 +385,6 @@ locals {
     },
 
     {
-      name  = "CF_PAGERDUTY_CLIENT_ID",
-      value = var.pager_duty_client_id
-    },
-    {
-      name  = "CF_PAGERDUTY_REDIRECT_URL",
-      value = "${var.app_url}/api/v1/oauth2/callback/pagerduty"
-    },
-    {
       name  = "CF_FRONTEND_URL",
       value = var.app_url
     },
@@ -413,15 +405,7 @@ locals {
       value = var.access_handler_service_connect_address
 
     },
-    {
-      name  = "CF_SLACK_CLIENT_ID",
-      value = var.slack_client_id
-    },
 
-    {
-      name  = "CF_SLACK_REDIRECT_URL",
-      value = "${var.app_url}/api/v1/oauth2/callback/slack"
-    },
     {
       name  = "CF_PG_USER",
       value = var.database_user
@@ -633,18 +617,6 @@ locals {
 
   // Only add these secrets if their values are provided
   control_plane_secrets = concat(
-    var.pager_duty_client_secret_ps_arn != "" ? [{
-      name      = "CF_PAGERDUTY_CLIENT_SECRET",
-      valueFrom = var.pager_duty_client_secret_ps_arn
-    }] : [],
-    var.slack_client_secret_ps_arn != "" ? [{
-      name      = "CF_SLACK_CLIENT_SECRET",
-      valueFrom = var.slack_client_secret_ps_arn
-    }] : [],
-    var.slack_signing_secret_ps_arn != "" ? [{
-      name      = "CF_SLACK_SIGNING_SECRET",
-      valueFrom = var.slack_signing_secret_ps_arn
-    }] : [],
     var.scim_token_ps_arn != "" ? [{
       name      = "CF_SCIM_TOKEN",
       valueFrom = var.scim_token_ps_arn

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -60,33 +60,6 @@ variable "release_tag" {
   type        = string
 }
 
-variable "pager_duty_client_id" {
-  description = "Specifies the private Pager Duty application client ID."
-  type        = string
-}
-
-variable "pager_duty_client_secret_ps_arn" {
-  description = "The AWS Parameter Store ARN for the Pager Duty app client secret."
-  default     = ""
-  type        = string
-}
-
-variable "slack_client_id" {
-  description = "Specifies the private Slack application client ID."
-  type        = string
-}
-
-variable "slack_client_secret_ps_arn" {
-  description = "The AWS Parameter Store ARN for the Slack application client secret."
-  default     = ""
-  type        = string
-}
-
-variable "slack_signing_secret_ps_arn" {
-  description = "The AWS Parameter Store ARN for the Slack application signing secret."
-  default     = ""
-  type        = string
-}
 
 variable "app_url" {
   description = "The app url (e.g., 'https://common-fate.mydomain.com')."

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "aws_region" {
 variable "release_tag" {
   description = "Override the application release tag to be used in the deployment. As of module version v1.13.0, application versions are bundled into the Terraform module, and so in most cases you should not override this."
   type        = string
-  default     = "v4.0.0"
+  default     = "v4.0.4"
 }
 
 variable "app_certificate_arn" {
@@ -32,6 +32,35 @@ variable "auth_certificate_arn" {
   default     = ""
 }
 
+variable "pager_duty_client_id" {
+  description = "(Deprecated) The private Pager Duty application client ID."
+  default     = ""
+  type        = string
+}
+
+variable "pager_duty_client_secret_ps_arn" {
+  description = "(Deprecated) The AWS Parameter Store ARN for the private Pager Duty application client secret."
+  default     = ""
+  type        = string
+}
+
+variable "slack_client_id" {
+  description = "(Deprecated) The private Slack application client ID."
+  default     = ""
+  type        = string
+}
+
+variable "slack_client_secret_ps_arn" {
+  description = "(Deprecated) The AWS Parameter Store ARN for the private Slack application client secret."
+  default     = ""
+  type        = string
+}
+
+variable "slack_signing_secret_ps_arn" {
+  description = "(Deprecated) The AWS Parameter Store ARN for the private Slack application signing secret."
+  default     = ""
+  type        = string
+}
 
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,35 +32,6 @@ variable "auth_certificate_arn" {
   default     = ""
 }
 
-variable "pager_duty_client_id" {
-  description = "The private Pager Duty application client ID."
-  default     = ""
-  type        = string
-}
-
-variable "pager_duty_client_secret_ps_arn" {
-  description = "The AWS Parameter Store ARN for the private Pager Duty application client secret."
-  default     = ""
-  type        = string
-}
-
-variable "slack_client_id" {
-  description = "The private Slack application client ID."
-  default     = ""
-  type        = string
-}
-
-variable "slack_client_secret_ps_arn" {
-  description = "The AWS Parameter Store ARN for the private Slack application client secret."
-  default     = ""
-  type        = string
-}
-
-variable "slack_signing_secret_ps_arn" {
-  description = "The AWS Parameter Store ARN for the private Slack application signing secret."
-  default     = ""
-  type        = string
-}
 
 
 


### PR DESCRIPTION
The application no longer depends on these to be provided as environment variables.
This is a non breaking change, the variables are marked as deprecated and no longer used