### PR TITLE
Allow 'common-fate-allow-assume-role' tag to be used for trust policies

### DIFF
--- a/.changeset/loud-chairs-matter.md
+++ b/.changeset/loud-chairs-matter.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fix an issue where the S3 Audit Log Destination write role used a confusing tag. The role can now be tagged with 'common-fate-allow-assume-role=true' to allow Common Fate to assume it.

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -351,6 +351,16 @@ data "aws_iam_policy_document" "assume_roles_policy_tagged" {
       values   = ["true"]
     }
   }
+
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:ResourceTag/common-fate-allow-assume-role"
+      values   = ["true"]
+    }
+  }
 }
 resource "aws_iam_policy" "assume_role_tagged" {
   name        = "${var.namespace}-${var.stage}-access-handler-ars-tagged"


### PR DESCRIPTION
Our S3 Audit Log Destination requires that Common Fate assumes a role to write to the bucket.

We currently use ABAC to limit the roles that the Control Plane can assume. Specifically, the Control Plane can only assume roles that are tagged with `common-fate-integration-read-role`.

The problem though is that this requires users to tag the S3 bucket write role with `common-fate-integration-read-role`.

This is confusing, because we're writing rather than reading.

This PR adds a new tag `common-fate-allow-assume-role` which can be used instead, and is less confusing.
