### PR TITLE
deprecate configuring the provisioner via the infrastructure

### DIFF
--- a/.changeset/poor-elephants-fetch.md
+++ b/.changeset/poor-elephants-fetch.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+deprecate configuring the provisioner via the infrastructure config

--- a/main.tf
+++ b/main.tf
@@ -348,13 +348,6 @@ module "provisioner" {
   auth_issuer                       = module.cognito.auth_issuer
   app_url                           = var.app_url
   assume_role_external_id           = var.assume_role_external_id
-
-  gcp_config                   = var.provisioner_gcp_config
-  aws_idc_config               = var.provisioner_aws_idc_config
-  entra_config                 = var.provisioner_entra_config
-  aws_rds_config               = var.provisioner_aws_rds_config
-  okta_config                  = var.provisioner_okta_config
-  datastax_config              = var.provisioner_datastax_config
-  auth0_config                 = var.provisioner_auth0_config
-  provisioner_image_repository = var.provisioner_image_repository
+  provisioner_image_repository      = var.provisioner_image_repository
+  aws_partition                     = data.aws_partition.current.id
 }

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -8,180 +8,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  aws_idc_config  = var.aws_idc_config != null ? var.aws_idc_config : {}
-  gcp_config      = var.gcp_config != null ? var.gcp_config : {}
-  entra_config    = var.entra_config != null ? var.entra_config : {}
-  aws_rds_config  = var.aws_rds_config != null ? var.aws_rds_config : {}
-  okta_config     = var.okta_config != null ? var.okta_config : {}
-  datastax_config = var.datastax_config != null ? var.datastax_config : {}
-  auth0_config    = var.auth0_config != null ? var.auth0_config : {}
-
-  provisioner_types = compact([
-    var.aws_idc_config != null ? "AWS_IDC" : "",
-    var.gcp_config != null ? "GCP" : "",
-    var.entra_config != null ? "Entra" : "",
-    var.aws_rds_config != null ? "AWS_RDS" : "",
-    var.okta_config != null ? "Okta" : "",
-    var.datastax_config != null ? "DataStax" : "",
-    var.auth0_config != null ? "Auth0" : "",
-  ])
-
-  env_vars = [
-    {
-      name  = "CF_PROVISIONER_TYPES"
-      value = join(",", local.provisioner_types)
-    },
-  ]
-
-
-  # Add AWS and GCP specific environment variables if their configurations are provided
-  aws_env_vars = var.aws_idc_config != null ? [
-    {
-      name  = "CF_AWS_ROLE_ARN"
-      value = local.aws_idc_config.role_arn
-    },
-    {
-      name  = "CF_AWS_IDC_REGION"
-      value = local.aws_idc_config.idc_region
-    },
-    {
-      name  = "CF_AWS_IDC_INSTANCE_ARN"
-      value = local.aws_idc_config.idc_instance_arn
-    },
-    {
-      name  = "CF_AWS_IDC_IDENTITY_STORE_ID"
-      value = local.aws_idc_config.idc_identity_store_id
-    },
-    {
-      name  = "CF_AWS_IDC_ASSUME_ROLE_EXTERNAL_ID"
-      value = var.assume_role_external_id
-    }
-  ] : []
-
-  gcp_env_vars = var.gcp_config != null ? [
-    {
-      name  = "CF_GCP_WORKLOAD_IDENTITY_CONFIG_JSON"
-      value = local.gcp_config.workload_identity_config_json
-    }
-  ] : []
-
-  gcp_secrets = var.gcp_config != null && lookup(local.gcp_config, "service_account_client_json_ps_arn", null) != null ? [
-    {
-      name      = "CF_GCP_SERVICE_ACCOUNT_CREDENTIALS_JSON",
-      valueFrom = local.gcp_config.service_account_client_json_ps_arn
-    }
-  ] : []
-
-  entra_env_vars = var.entra_config != null ? [
-    {
-      name  = "CF_ENTRA_TENANT_ID"
-      value = local.entra_config.tenant_id
-    },
-    {
-      name  = "CF_ENTRA_CLIENT_ID"
-      value = local.entra_config.client_id
-    }
-  ] : []
-
-
-  entra_client_secret_path_arn = var.entra_config != null ? "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.entra_config.client_secret_secret_path}" : ""
-
-  entra_secrets = var.entra_config != null ? [
-    {
-      name = "CF_ENTRA_CLIENT_SECRET",
-      // construct the arn from a path to make configuration most simple and consistent accross infra and config
-      valueFrom = local.entra_client_secret_path_arn
-    }
-  ] : []
-
-  aws_rds_env_vars = var.aws_rds_config != null ? [
-    {
-      name  = "CF_AWS_RDS_IDC_ROLE_ARN"
-      value = local.aws_rds_config.idc_role_arn
-    },
-    {
-      name  = "CF_AWS_RDS_IDC_REGION"
-      value = local.aws_rds_config.idc_region
-    },
-    {
-      name  = "CF_AWS_RDS_IDC_INSTANCE_ARN"
-      value = local.aws_rds_config.idc_instance_arn
-    },
-    {
-      name  = "CF_AWS_RDS_INFRA_ROLE_NAME"
-      value = local.aws_rds_config.infra_role_name
-    },
-    {
-      name  = "CF_AWS_RDS_SHOULD_PROVISION_SG"
-      value = var.aws_rds_config.should_provision_security_groups == null ? false : var.aws_rds_config.should_provision_security_groups
-    },
-    {
-      name  = "CF_AWS_RDS_ASSUME_ROLE_EXTERNAL_ID"
-      value = var.assume_role_external_id
-    }
-  ] : []
-
-  okta_env_vars = var.okta_config != null ? [
-    {
-      name  = "CF_OKTA_ORGANIZATION_ID"
-      value = local.okta_config.organization_id
-    }
-  ] : []
-
-  okta_api_key_secret_path_arn = var.okta_config != null ? "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.okta_config.api_key_secret_path}" : ""
-  okta_secrets = var.okta_config != null ? [
-    {
-      name = "CF_OKTA_API_KEY_SECRET",
-      // construct the arn from a path to make configuration more simple and consistent accross infra and config
-      valueFrom = local.okta_api_key_secret_path_arn
-    }
-  ] : []
-
-  datastax_api_key_secret_path_arn = var.datastax_config != null ? "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.datastax_config.api_key_secret_path}" : ""
-  datastax_secrets = var.datastax_config != null ? [
-    {
-      name = "CF_DATASTAX_API_KEY_SECRET",
-      // construct the arn from a path to make configuration more simple and consistent accross infra and config
-      valueFrom = local.datastax_api_key_secret_path_arn
-    }
-  ] : []
-
-  auth0_env_vars = var.okta_config != null ? [
-    {
-      name  = "CF_AUTH0_DOMAIN"
-      value = local.auth0_config.domain
-    },
-    {
-      name  = "CF_AUTH0_CLIENT_ID"
-      value = local.auth0_config.client_id
-    }
-  ] : []
-
-  auth0_client_secret_secret_path_arn = var.auth0_config != null ? "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${local.auth0_config.client_secret_secret_path}" : ""
-  auth0_secrets = var.auth0_config != null ? [
-    {
-      name = "CF_AUTH0_CLIENT_SECRET",
-      // construct the arn from a path to make configuration more simple and consistent accross infra and config
-      valueFrom = local.auth0_client_secret_secret_path_arn
-    }
-  ] : []
-
-  // @TODO remove this eventually as it has been replaced with a tag condition key
-  grant_assume_roles = compact([
-    var.aws_idc_config != null ? var.aws_idc_config.role_arn : "",
-  ])
-
-  grant_read_secret_arns = compact([
-    var.gcp_config != null ? var.gcp_config.service_account_client_json_ps_arn : "",
-    var.entra_config != null ? local.entra_client_secret_path_arn : "",
-    var.okta_config != null ? local.okta_api_key_secret_path_arn : "",
-    var.datastax_config != null ? local.datastax_api_key_secret_path_arn : "",
-    var.auth0_config != null ? local.auth0_client_secret_secret_path_arn : "",
-  ])
-
-  combined_env_vars = concat(local.env_vars, local.aws_env_vars, local.gcp_env_vars, local.entra_env_vars, local.aws_rds_env_vars, local.okta_env_vars, local.auth0_env_vars)
-  combined_secrets  = concat(local.gcp_secrets, local.entra_secrets, local.okta_secrets, local.datastax_secrets, local.auth0_secrets)
-  name_prefix       = join("-", compact([var.namespace, var.stage, var.name_prefix]))
+  name_prefix = join("-", compact([var.namespace, var.stage, var.name_prefix]))
 }
 
 # Use 'local.combined_env_vars' wherever you need to pass these environment variables
@@ -282,54 +109,31 @@ resource "aws_iam_role" "provisioner_ecs_task_role" {
 
 
 resource "aws_iam_policy" "parameter_store_secrets_read_access" {
-  count       = length(local.grant_read_secret_arns) > 0 ? 1 : 0
   name        = "${local.name_prefix}-provisioner-ps"
-  description = "Allows read secret from parameter store"
+  description = "Allows reading secrets from SSM Parameter Store"
 
   policy = jsonencode({
     Version = "2012-10-17",
-    // include only the secrets that are configured
     Statement = [
-      for arn in local.grant_read_secret_arns :
       {
         Effect = "Allow"
         Action = [
           "ssm:GetParameter",
           "ssm:GetParameters",
         ]
-        Resource = arn
+        Resource = [
+          "arn:${var.aws_partition}:ssm:${var.aws_region}:${var.aws_account_id}:parameter/${var.namespace}/${var.stage}/*",
+        ]
       }
     ]
   })
 }
 
 resource "aws_iam_role_policy_attachment" "provisioner_ecs_task_parameter_store_secrets_read_access_attach" {
-  count      = length(local.grant_read_secret_arns) > 0 ? 1 : 0
   role       = aws_iam_role.provisioner_ecs_execution_role.name
   policy_arn = aws_iam_policy.parameter_store_secrets_read_access[0].arn
 }
 
-
-data "aws_iam_policy_document" "assume_roles_policy" {
-  count = length(local.grant_assume_roles) == 0 ? 0 : 1
-  statement {
-    actions   = ["sts:AssumeRole"]
-    resources = local.grant_assume_roles
-  }
-}
-resource "aws_iam_policy" "assume_provisioner_role" {
-  count       = length(local.grant_assume_roles) == 0 ? 0 : 1
-  name        = "${local.name_prefix}-provisioner-ar"
-  description = "A policy allowing sts:AssumeRole on selected roles"
-  policy      = data.aws_iam_policy_document.assume_roles_policy[0].json
-}
-
-resource "aws_iam_role_policy_attachment" "assume_roles_policy_attach" {
-  count      = length(local.grant_assume_roles) == 0 ? 0 : 1
-  role       = aws_iam_role.provisioner_ecs_task_role.name
-  policy_arn = aws_iam_policy.assume_provisioner_role[0].arn
-
-}
 data "aws_iam_policy_document" "assume_roles_policy_tagged" {
   statement {
     actions   = ["sts:AssumeRole"]
@@ -370,7 +174,7 @@ resource "aws_ecs_task_definition" "provisioner_task" {
     portMappings = [{
       containerPort = 9999,
     }],
-    environment = concat([
+    environment = [
       {
         name  = "LOG_LEVEL"
         value = var.enable_verbose_logging ? "DEBUG" : "INFO"
@@ -399,9 +203,7 @@ resource "aws_ecs_task_definition" "provisioner_task" {
         name  = "CF_ASSUME_ROLE_EXTERNAL_ID"
         value = var.assume_role_external_id
       },
-    ], local.combined_env_vars),
-
-    secrets = local.combined_secrets
+    ],
 
 
     logConfiguration = {

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -11,7 +11,6 @@ locals {
   name_prefix = join("-", compact([var.namespace, var.stage, var.name_prefix]))
 }
 
-# Use 'local.combined_env_vars' wherever you need to pass these environment variables
 #trivy:ignore:AVD-AWS-0104
 resource "aws_security_group" "ecs_provisioner_sg_v2" {
   name        = "${local.name_prefix}-provisioner"

--- a/modules/provisioner/variables.tf
+++ b/modules/provisioner/variables.tf
@@ -45,7 +45,9 @@ variable "aws_region" {
   description = "Determines the AWS Region for deployment."
   type        = string
 }
-
+variable "aws_partition" {
+  description = "The AWS partition the module is being deployed to"
+}
 variable "aws_account_id" {
   description = "Determines the AWS account ID for deployment."
   type        = string
@@ -117,118 +119,6 @@ variable "provisioner_service_client_secret" {
 variable "auth_issuer" {
   description = "Specifies the issuer for authentication."
   type        = string
-}
-
-
-variable "aws_idc_config" {
-  description = <<EOF
-  Configuration for AWS IDC. The following keys are expected:
-  - role_arn: The ARN of the IAM role for the provisioner to assume which has permissions to provision access in an AWS organization.
-  - idc_region: The AWS IDC Region.
-  - idc_instance_arn: The AWS Identity Center instance ARN.
-  - idc_identity_store_id: The AWS IAM Identity Center Identity Store ID.
-  EOF
-  type = object({
-    role_arn         = string
-    idc_region       = string
-    idc_instance_arn = string
-
-    // optional for the moment to avoid making breaking changes.
-    idc_identity_store_id = optional(string)
-  })
-  default = null
-}
-
-variable "gcp_config" {
-  description = <<EOF
-  Configuration for GCP. The following keys are expected:
-  - service_account_client_json_ps_arn: (Optional) when using service account credentials, this is ARN of the secret credentials.
-  - workload_identity_config_json: (Optional) using Workload Identity Federation, this is the config file.
-
-  Either `workload_identity_config_json` or `service_account_client_json_ps_arn` must be provided (not both).
-  EOF
-  type = object({
-    service_account_client_json_ps_arn = optional(string)
-    workload_identity_config_json      = optional(string)
-  })
-  default = null
-}
-
-
-variable "entra_config" {
-  description = <<EOF
-  Configuration for GCP. The following keys are expected:
-  - tenant_id: The Entra tenant ID.
-  - client_id: The client ID for the Entra App Registration.
-  - client_secret_secret_path: The SSM Parameter store secret path for the client secret for the Entra App Registration.
-  EOF
-  type = object({
-    tenant_id                 = string
-    client_id                 = string
-    client_secret_secret_path = string
-  })
-  default = null
-}
-
-
-variable "aws_rds_config" {
-  description = <<EOF
-  Configuration for AWS RDS. The following keys are expected:
-  - idc_role_arn: The ARN of the IAM role for the provisioner to assume which has permissions to create and delete permission sets and provision access in an AWS organization.
-  - idc_region: The AWS IDC Region.
-  - idc_instance_arn: The AWS Identity Center instance ARN.
-  - infra_role_name: The name of the IAM role which is deployed each each account containing databases.
-  - should_provision_security_groups: (Optional) Whether or not the provisioner should attempt to provision security groups. Set this to true if you are not using pre deployed security groups.
-  EOF
-  type = object({
-    idc_role_arn                     = string
-    idc_region                       = string
-    idc_instance_arn                 = string
-    infra_role_name                  = string
-    should_provision_security_groups = optional(bool)
-  })
-  default = null
-}
-
-
-variable "okta_config" {
-  description = <<EOF
-  Configuration for Okta. The following keys are expected:
-  - organization_id: The ID of your Okta organization.
-  - api_key_secret_path: The SSM Parameter store secret path for the api key for the Okta organization.
-  EOF
-  type = object({
-    organization_id     = string
-    api_key_secret_path = string
-  })
-  default = null
-}
-
-variable "datastax_config" {
-  description = <<EOF
-  Configuration for DataStax. The following keys are expected:
-  - api_key_secret_path: The SSM Parameter store secret path for the api key for the DataStax organization.
-  EOF
-  type = object({
-    api_key_secret_path = string
-  })
-  default = null
-}
-
-
-variable "auth0_config" {
-  description = <<EOF
-  Configuration for Auth0. The following keys are expected:
-  - domain: The Auth0 tenant domain.
-  - client_id: The Auth0 application client ID.
-  - client_secret_secret_path: The SSM Parameter store secret path for the Auth0 application client secret.
-  EOF
-  type = object({
-    domain                    = string
-    client_id                 = string
-    client_secret_secret_path = string
-  })
-  default = null
 }
 
 variable "assume_role_external_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -174,6 +174,7 @@ variable "ecs_opentelemetry_collector_log_retention_in_days" {
 
 variable "provisioner_aws_idc_config" {
   description = <<EOF
+  (Deprecated)
   Configuration for AWS IDC. The following keys are expected:
   - role_arn: The ARN of the IAM role for the provisioner to assume which hass permissions to provision access in an AWS organization.
   - idc_region: The AWS IDC Region.
@@ -191,6 +192,7 @@ variable "provisioner_aws_idc_config" {
 
 variable "provisioner_gcp_config" {
   description = <<EOF
+  (Deprecated)
   Configuration for GCP. The following keys are expected:
   - service_account_client_json_ps_arn: (Optional) when using service account credentials, this is ARN of the secret credentials.
   - workload_identity_config_json: (Optional) using Workload Identity Federation, this is the config file.
@@ -207,6 +209,7 @@ variable "provisioner_gcp_config" {
 
 variable "provisioner_entra_config" {
   description = <<EOF
+  (Deprecated)
   Configuration for GCP. The following keys are expected:
   - tenant_id: The Entra tenant ID.
   - client_id: The client ID for the Entra App Registration.
@@ -223,6 +226,7 @@ variable "provisioner_entra_config" {
 
 variable "provisioner_aws_rds_config" {
   description = <<EOF
+  (Deprecated)
   Configuration for AWS RDS. The following keys are expected:
   - idc_role_arn: The ARN of the IAM role for the provisioner to assume which hass permissions to provision access in an AWS organization.
   - idc_region: The AWS IDC Region.
@@ -242,6 +246,7 @@ variable "provisioner_aws_rds_config" {
 
 variable "provisioner_okta_config" {
   description = <<EOF
+  (Deprecated)
   Configuration for Okta. The following keys are expected:
   - organization_id: The ID of your Okta organization.
   - api_key_secret_path: The SSM Parameter store secret path for the api key for the Okta organization.
@@ -256,6 +261,7 @@ variable "provisioner_okta_config" {
 
 variable "provisioner_datastax_config" {
   description = <<EOF
+  (Deprecated)
   Configuration for DataStax. The following keys are expected:
   - api_key_secret_path: The SSM Parameter store secret path for the api key for the DataStax organization.
   EOF
@@ -268,6 +274,7 @@ variable "provisioner_datastax_config" {
 
 variable "provisioner_auth0_config" {
   description = <<EOF
+  (Deprecated)
   Configuration for Auth0. The following keys are expected:
   - domain: The Auth0 tenant domain.
   - client_id: The Auth0 application client ID.


### PR DESCRIPTION
Following on from the previous release, the provisioner now gets its configuration in a provisioning API request, and so the configuration in the infrastructure is no longer used.

This PR marks the fields as deprecated but does not remove them, which allows for easy rollbacks