### PR TITLE
Increase the default ALB idle connection timeout to 2.5 minutes

### DIFF
--- a/.changeset/fast-shoes-yawn.md
+++ b/.changeset/fast-shoes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Update default idle timeout on the ALB to 2m 30s to accomodate for the retry timeouts in the provisioners

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -37,7 +37,7 @@ resource "aws_lb" "main_alb" {
   subnets                          = var.public_subnet_ids
   enable_cross_zone_load_balancing = true
   drop_invalid_header_fields       = true
-
+  idle_timeout                     = 140 // 2 minute 30 seconds aligns with 2 minute timeouts on provisioning
 }
 
 locals {


### PR DESCRIPTION
This should fix issues seen when requesting many entitlements during an AWS service degradation.
The provisioner retry timeouts are set at 2 minutes currently and provisioning happens synchronously.