### PR TITLE
Fix permissions for provisioner secrets access

### DIFF
--- a/.changeset/loud-icons-sniff.md
+++ b/.changeset/loud-icons-sniff.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fixes a permissions issue which prevented the provisioner from reading secrets from SSM Parameter store at runtime, for integrations such as Okta, Entra, Auth0

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -134,7 +134,7 @@ resource "aws_iam_role_policy_attachment" "otel" {
 }
 
 resource "aws_iam_role_policy_attachment" "provisioner_ecs_task_parameter_store_secrets_read_access_attach" {
-  role       = aws_iam_role.provisioner_ecs_execution_role.name
+  role       = aws_iam_role.provisioner_ecs_task_role.name
   policy_arn = aws_iam_policy.parameter_store_secrets_read_access.arn
 }
 


### PR DESCRIPTION
In our upgrade to provisioner not depending on the infrastructure configuration, the role granting access to secrets was supposed to be switched to the task role.

It was still on the execution role which prevented integrations requiring secrets to work.