### PR TITLE
Fix a cyclic reference issue when 'app_certificate_arn' depends on another module

### DIFF
--- a/.changeset/modern-weeks-approve.md
+++ b/.changeset/modern-weeks-approve.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fixes a cyclic reference issue when the ALB certificate ARN depends on the output of another Terraform module.

--- a/main.tf
+++ b/main.tf
@@ -45,12 +45,10 @@ module "vpc" {
 }
 
 module "alb" {
-  source    = "./modules/alb"
-  namespace = var.namespace
-  stage     = var.stage
-  certificate_arns = [
-    var.app_certificate_arn
-  ]
+  source                     = "./modules/alb"
+  namespace                  = var.namespace
+  stage                      = var.stage
+  certificate_arn            = var.app_certificate_arn
   public_subnet_ids          = local.public_subnet_ids
   vpc_id                     = local.vpc_id
   use_internal_load_balancer = var.use_internal_load_balancer
@@ -336,5 +334,3 @@ module "authz-legacy" {
   namespace = var.namespace
   stage     = var.stage
 }
-
-

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -40,9 +40,6 @@ resource "aws_lb" "main_alb" {
   idle_timeout                     = 140 // 2 minute 30 seconds aligns with 2 minute timeouts on provisioning
 }
 
-locals {
-  distinct_certificates = distinct(var.certificate_arns)
-}
 // The listener is configured to use SNI for multiple certificates if provided
 // else it will just use a single cert if all provided arns are the same
 resource "aws_lb_listener" "https_listener" {
@@ -51,7 +48,7 @@ resource "aws_lb_listener" "https_listener" {
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
 
-  certificate_arn = element(local.distinct_certificates, 0)
+  certificate_arn = var.certificate_arn
 
   default_action {
     type = "fixed-response"
@@ -83,7 +80,7 @@ resource "aws_lb_listener" "http" {
 
 // if there are any other distict certificates, add them to the listener
 resource "aws_lb_listener_certificate" "additional_certs" {
-  for_each        = { for idx, cert_arn in local.distinct_certificates : idx => cert_arn if idx > 0 }
+  for_each        = var.additional_certificate_arns
   listener_arn    = aws_lb_listener.https_listener.arn
   certificate_arn = each.value
 }

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -16,14 +16,15 @@ variable "vpc_id" {
 }
 
 
-variable "certificate_arns" {
+variable "certificate_arn" {
   description = "The Amazon Certificate Manager (ACM) certificate ARN for the domains served by this load balancer"
-  type        = list(string)
+  type        = string
+}
 
-  validation {
-    condition     = length(var.certificate_arns) > 0
-    error_message = "The certificate_arns list must contain at least one certificate ARN."
-  }
+variable "additional_certificate_arns" {
+  description = "The Amazon Certificate Manager (ACM) certificate ARN for the domains served by this load balancer"
+  type        = set(string)
+  default     = []
 }
 
 


### PR DESCRIPTION
Removes the `distinct(var.certificate_arns)` which is causing the following error when
a dynamic app certificate is used:

```
│ Error: Invalid for_each argument
│
│   on .terraform/modules/common-fate-deployment/modules/alb/main.tf line 86, in resource "aws_lb_listener_certificate" "additional_certs":
│   86:   for_each        = { for idx, cert_arn in local.distinct_certificates : idx => cert_arn if idx > 0 }
│     ├────────────────
│     │ local.distinct_certificates is a list of string, known only after apply
```

This is a non-breaking change, because we only use a single certificate ARN in the ALB anyway.
