### PR TITLE
Remove deprecated variables and add changesets

### DIFF
--- a/.changeset/honest-pants-move.md
+++ b/.changeset/honest-pants-move.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+For BYOC Customers: Removes team_name and logo_url variables and support for customising the appearance of the web app.

--- a/.changeset/lemon-bananas-hide.md
+++ b/.changeset/lemon-bananas-hide.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+For BYOC Customers: This change removes the PagerDuty and Slack configuration from the infrastructure stack. These integrations are now entirely configured in the application config.

--- a/.changeset/silent-donkeys-mate.md
+++ b/.changeset/silent-donkeys-mate.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+For BYOC Customers: This change removes the provisioner config variables from the infrastructure stack. To upgrade, you will need to remove any references to these variables in your config. The provisioner is now configured entirely from the application configuration.

--- a/.changeset/strong-ads-crash.md
+++ b/.changeset/strong-ads-crash.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+For BYOC Customers: This change removes unstable_enable_feature_least_privilege, unstable_sync_idc_cloudtrail_schedule and unstable_least_privilege_analysis_schedule variables as this feature has been removed from the application.

--- a/main.tf
+++ b/main.tf
@@ -237,8 +237,6 @@ module "web" {
   auth_cli_client_id    = module.cognito.cli_client_id
   auth_url              = module.cognito.auth_url
   auth_web_client_id    = module.cognito.web_client_id
-  logo_url              = var.logo_url
-  team_name             = var.team_name
   ecs_cluster_id        = local.ecs_cluster_id
   alb_listener_arn      = module.alb.listener_arn
   app_url               = var.app_url

--- a/main.tf
+++ b/main.tf
@@ -147,63 +147,58 @@ module "control_plane" {
   namespace = var.namespace
   stage     = var.stage
 
-  aws_region                                 = var.aws_region
-  aws_account_id                             = data.aws_caller_identity.current.account_id
-  aws_partition                              = data.aws_partition.current.id
-  database_secret_sm_arn                     = module.control_plane_db.secret_arn
-  database_security_group_id                 = module.control_plane_db.security_group_id
-  eventbus_arn                               = module.events.event_bus_arn
-  sqs_queue_arn                              = module.events.sqs_queue_arn
-  app_url                                    = var.app_url
-  release_tag                                = var.release_tag
-  scim_source                                = var.scim_source
-  scim_token_ps_arn                          = var.scim_token_ps_arn
-  subnet_ids                                 = local.private_subnet_ids
-  vpc_id                                     = local.vpc_id
-  ecs_cluster_id                             = local.ecs_cluster_id
-  database_host                              = module.control_plane_db.endpoint
-  database_user                              = module.control_plane_db.username
-  alb_listener_arn                           = module.alb.listener_arn
-  sqs_queue_name                             = module.events.sqs_queue_name
-  auth_issuer                                = module.cognito.auth_issuer
-  control_plane_service_client_id            = module.cognito.control_plane_service_client_id
-  control_plane_service_client_secret        = module.cognito.control_plane_service_client_secret
-  slack_service_client_id                    = module.cognito.slack_service_client_id
-  slack_service_client_secret                = module.cognito.slack_service_client_secret
-  oidc_slack_issuer                          = module.cognito.auth_issuer
-  licence_key                                = local.licence_key_value
-  log_level                                  = var.control_plane_log_level
-  grant_assume_on_role_arns                  = var.control_plane_grant_assume_on_role_arns
-  oidc_control_plane_issuer                  = module.cognito.auth_issuer
-  otel_log_group_name                        = module.ecs_base.otel_log_group_name
-  otel_writer_iam_policy_arn                 = module.ecs_base.otel_writer_iam_policy_arn
-  alb_security_group_id                      = module.alb.alb_security_group_id
-  additional_cors_allowed_origins            = var.additional_cors_allowed_origins
-  unstable_enable_feature_least_privilege    = var.unstable_enable_feature_least_privilege
-  unstable_least_privilege_analysis_schedule = var.unstable_least_privilege_analysis_schedule
-  unstable_sync_idc_cloudtrail_schedule      = var.unstable_sync_idc_cloudtrail_schedule
-  report_bucket_arn                          = module.report_bucket.arn
-  report_bucket_name                         = module.report_bucket.id
-  assume_role_external_id                    = var.assume_role_external_id
-  authz_eval_bucket_name                     = module.authz_eval_bucket.id
-  authz_eval_bucket_arn                      = module.authz_eval_bucket.arn
-  control_image_repository                   = var.control_image_repository
-  worker_image_repository                    = var.worker_image_repository
-  service_discovery_namespace_arn            = module.ecs_base.service_discovery_namespace_arn
-  access_handler_security_group_id           = module.access_handler.security_group_id
-  access_handler_service_connect_address     = module.access_handler.access_handler_internal_address
-  xray_monitoring_enabled                    = var.xray_monitoring_enabled
-  managed_monitoring_enabled                 = var.managed_monitoring_enabled
-  managed_monitoring_endpoint                = var.managed_monitoring_endpoint
-  factory_base_url                           = var.factory_base_url
-  factory_oidc_issuer                        = var.factory_oidc_issuer
-  unstable_feature_embedded_authorizations   = var.unstable_feature_embedded_authorizations
-  force_rerun_config_migrations              = var.force_rerun_config_migrations
-  database_auto_migrate                      = var.database_auto_migrate
-  oidc_access_handler_service_client_id      = module.cognito.access_handler_service_client_id
-  oidc_provisioner_service_client_id         = module.cognito.provisioner_client_id
-  oidc_terraform_client_id                   = module.cognito.terraform_client_id
-  oidc_read_only_client_id                   = module.cognito.read_only_client_id
+  aws_region                             = var.aws_region
+  aws_account_id                         = data.aws_caller_identity.current.account_id
+  aws_partition                          = data.aws_partition.current.id
+  database_secret_sm_arn                 = module.control_plane_db.secret_arn
+  database_security_group_id             = module.control_plane_db.security_group_id
+  eventbus_arn                           = module.events.event_bus_arn
+  sqs_queue_arn                          = module.events.sqs_queue_arn
+  app_url                                = var.app_url
+  release_tag                            = var.release_tag
+  scim_source                            = var.scim_source
+  scim_token_ps_arn                      = var.scim_token_ps_arn
+  subnet_ids                             = local.private_subnet_ids
+  vpc_id                                 = local.vpc_id
+  ecs_cluster_id                         = local.ecs_cluster_id
+  database_host                          = module.control_plane_db.endpoint
+  database_user                          = module.control_plane_db.username
+  alb_listener_arn                       = module.alb.listener_arn
+  sqs_queue_name                         = module.events.sqs_queue_name
+  auth_issuer                            = module.cognito.auth_issuer
+  control_plane_service_client_id        = module.cognito.control_plane_service_client_id
+  control_plane_service_client_secret    = module.cognito.control_plane_service_client_secret
+  slack_service_client_id                = module.cognito.slack_service_client_id
+  slack_service_client_secret            = module.cognito.slack_service_client_secret
+  oidc_slack_issuer                      = module.cognito.auth_issuer
+  licence_key                            = local.licence_key_value
+  log_level                              = var.control_plane_log_level
+  grant_assume_on_role_arns              = var.control_plane_grant_assume_on_role_arns
+  oidc_control_plane_issuer              = module.cognito.auth_issuer
+  otel_log_group_name                    = module.ecs_base.otel_log_group_name
+  otel_writer_iam_policy_arn             = module.ecs_base.otel_writer_iam_policy_arn
+  alb_security_group_id                  = module.alb.alb_security_group_id
+  additional_cors_allowed_origins        = var.additional_cors_allowed_origins
+  report_bucket_arn                      = module.report_bucket.arn
+  report_bucket_name                     = module.report_bucket.id
+  assume_role_external_id                = var.assume_role_external_id
+  authz_eval_bucket_name                 = module.authz_eval_bucket.id
+  authz_eval_bucket_arn                  = module.authz_eval_bucket.arn
+  control_image_repository               = var.control_image_repository
+  worker_image_repository                = var.worker_image_repository
+  service_discovery_namespace_arn        = module.ecs_base.service_discovery_namespace_arn
+  access_handler_security_group_id       = module.access_handler.security_group_id
+  access_handler_service_connect_address = module.access_handler.access_handler_internal_address
+  xray_monitoring_enabled                = var.xray_monitoring_enabled
+  managed_monitoring_enabled             = var.managed_monitoring_enabled
+  managed_monitoring_endpoint            = var.managed_monitoring_endpoint
+  factory_base_url                       = var.factory_base_url
+  factory_oidc_issuer                    = var.factory_oidc_issuer
+  database_auto_migrate                  = var.database_auto_migrate
+  oidc_access_handler_service_client_id  = module.cognito.access_handler_service_client_id
+  oidc_provisioner_service_client_id     = module.cognito.provisioner_client_id
+  oidc_terraform_client_id               = module.cognito.terraform_client_id
+  oidc_read_only_client_id               = module.cognito.read_only_client_id
 }
 
 
@@ -251,7 +246,6 @@ module "web" {
   alb_security_group_id = module.alb.alb_security_group_id
   web_image_repository  = var.web_image_repository
   centralised_support   = var.centralised_support
-  hierarchy_ui          = var.hierarchy_ui
 }
 
 
@@ -293,7 +287,6 @@ module "access_handler" {
   managed_monitoring_endpoint               = var.managed_monitoring_endpoint
   factory_base_url                          = var.factory_base_url
   factory_oidc_issuer                       = var.factory_oidc_issuer
-  unstable_feature_embedded_authorizations  = var.unstable_feature_embedded_authorizations
 }
 
 

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -298,10 +298,6 @@ resource "aws_ecs_task_definition" "access_handler_task" {
           name  = "CF_DEPLOYMENT_NAME",
           value = var.stage
         },
-        {
-          name  = "CF_FEATURE_EMBEDDED_AUTHORIZATIONS",
-          value = var.unstable_feature_embedded_authorizations ? "true" : "false"
-        },
       ],
       secrets = [
         {

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -218,8 +218,3 @@ variable "factory_oidc_issuer" {
   default     = "https://factory.commonfate.io"
 }
 
-variable "unstable_feature_embedded_authorizations" {
-  type        = bool
-  default     = false
-  description = "Opt-in to enable Embedded Authorization (in early access). This variable will be removed once the feature is released."
-}

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -530,18 +530,6 @@ locals {
       value = "*/5 * * * *"
     },
     {
-      name  = "CF_FEATURE_LEAST_PRIVILEGE_ENABLED",
-      value = var.unstable_enable_feature_least_privilege ? "true" : "false"
-    },
-    {
-      name  = "CF_SYNC_IDC_CLOUDTRAIL_CRON_SCHEDULE",
-      value = var.unstable_sync_idc_cloudtrail_schedule
-    },
-    {
-      name  = "CF_LEAST_PRIVILEGE_ANALYSIS_CRON_SCHEDULE",
-      value = var.unstable_least_privilege_analysis_schedule
-    },
-    {
       name  = "CF_REPORT_S3_BUCKET",
       value = var.report_bucket_name
     },
@@ -592,13 +580,6 @@ locals {
     {
       name  = "CF_DEPLOYMENT_NAME",
       value = var.stage
-    },
-    {
-      name  = "CF_FEATURE_EMBEDDED_AUTHORIZATIONS",
-      value = var.unstable_feature_embedded_authorizations ? "true" : "false"
-
-      name  = "CF_FORCE_CONFIG_MIGRATIONS",
-      value = var.force_rerun_config_migrations ? "true" : "false"
     },
     {
       name  = "CF_TERRAFORM_SERVICE_OIDC_CLIENT_ID",

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -215,25 +215,6 @@ variable "additional_cors_allowed_origins" {
   description = "Additional origins to add to the CORS allowlist. By default, the app URL is automatically added."
 }
 
-
-variable "unstable_enable_feature_least_privilege" {
-  type        = bool
-  default     = false
-  description = "Opt-in to enable Least Privilege Analytics (in early access). This variable will be removed once the feature is released."
-}
-
-variable "unstable_sync_idc_cloudtrail_schedule" {
-  type        = string
-  default     = "13 0 * * *"
-  description = "Least Privilege Analytics: the schedule to sync AWS CloudTrail events on"
-}
-
-variable "unstable_least_privilege_analysis_schedule" {
-  type        = string
-  default     = "13 5 * * *"
-  description = "Least Privilege Analytics: the schedule to build least privilege reports on"
-}
-
 variable "report_bucket_arn" {
   type        = string
   description = "ARN of report bucket"
@@ -325,15 +306,6 @@ variable "factory_oidc_issuer" {
   default     = "https://factory.commonfate.io"
 }
 
-variable "unstable_feature_embedded_authorizations" {
-  type        = bool
-  default     = false
-  description = "Opt-in to enable Embedded Authorization (in early access). This variable will be removed once the feature is released."
-}
-variable "force_rerun_config_migrations" {
-  type        = bool
-  description = "Whether to force the config migration to rerun on startup of the control plane"
-}
 variable "database_auto_migrate" {
   type        = bool
   default     = true

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -115,14 +115,6 @@ resource "aws_ecs_task_definition" "web_task" {
         value = "${coalesce(var.authz_api_url, var.app_url)}/graph"
       },
       {
-        name  = "CF_TEAM_NAME"
-        value = var.team_name
-      },
-      {
-        name  = "CF_LOGO_URL"
-        value = var.logo_url
-      },
-      {
         name  = "CF_COGNITO_USER_POOL_DOMAIN"
         value = var.auth_url
       },

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -138,9 +138,10 @@ resource "aws_ecs_task_definition" "web_task" {
         name  = "CF_CENTRALISED_SUPPORT",
         value = var.centralised_support ? "true" : "false"
       },
+      // @TODO: remove once the flag is removed in the web app
       {
         name  = "CF_HIERARCHY_UI",
-        value = var.hierarchy_ui ? "true" : "false"
+        value = "true"
       },
     ]
 

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -76,16 +76,6 @@ variable "auth_url" {
   }
 }
 
-variable "team_name" {
-  description = "Specifies the team name for branding the frontend."
-  type        = string
-}
-
-variable "logo_url" {
-  description = "Specifies a public URL for the logo used in frontend branding."
-  type        = string
-}
-
 variable "auth_authority_url" {
   description = "Specifies the URL used for authentication."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -47,17 +47,7 @@ variable "app_url" {
     error_message = "The app_url must start with 'https://'."
   }
 }
-variable "team_name" {
-  description = "Specifies the team name used for branding on the frontend."
-  default     = "Common Fate"
-  type        = string
-}
 
-variable "logo_url" {
-  description = "Specifies a public logo URL for frontend branding."
-  default     = ""
-  type        = string
-}
 variable "saml_provider_name" {
   description = "The name of the identity provider (e.g., 'Entra') displayed on the login screen."
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -32,38 +32,6 @@ variable "auth_certificate_arn" {
   default     = ""
 }
 
-variable "pager_duty_client_id" {
-  description = "(Deprecated) The private Pager Duty application client ID."
-  default     = ""
-  type        = string
-}
-
-variable "pager_duty_client_secret_ps_arn" {
-  description = "(Deprecated) The AWS Parameter Store ARN for the private Pager Duty application client secret."
-  default     = ""
-  type        = string
-}
-
-variable "slack_client_id" {
-  description = "(Deprecated) The private Slack application client ID."
-  default     = ""
-  type        = string
-}
-
-variable "slack_client_secret_ps_arn" {
-  description = "(Deprecated) The AWS Parameter Store ARN for the private Slack application client secret."
-  default     = ""
-  type        = string
-}
-
-variable "slack_signing_secret_ps_arn" {
-  description = "(Deprecated) The AWS Parameter Store ARN for the private Slack application signing secret."
-  default     = ""
-  type        = string
-}
-
-
-
 variable "auth_url" {
   description = "The custom auth url (e.g., 'https://auth.mydomain.com'). Provide this and the auth_certificate_arn to configure cognito with a custom domain."
   type        = string
@@ -79,21 +47,17 @@ variable "app_url" {
     error_message = "The app_url must start with 'https://'."
   }
 }
-
 variable "team_name" {
   description = "Specifies the team name used for branding on the frontend."
   default     = "Common Fate"
   type        = string
 }
 
-
-
 variable "logo_url" {
   description = "Specifies a public logo URL for frontend branding."
   default     = ""
   type        = string
 }
-
 variable "saml_provider_name" {
   description = "The name of the identity provider (e.g., 'Entra') displayed on the login screen."
   default     = ""
@@ -153,11 +117,6 @@ variable "control_plane_log_level" {
   default     = "INFO"
 }
 
-variable "authz_log_level" {
-  description = "Log level for Authz service"
-  type        = string
-  default     = "INFO"
-}
 
 variable "additional_cors_allowed_origins" {
   type        = list(string)
@@ -171,142 +130,6 @@ variable "ecs_opentelemetry_collector_log_retention_in_days" {
   type        = number
 }
 
-
-variable "provisioner_aws_idc_config" {
-  description = <<EOF
-  (Deprecated)
-  Configuration for AWS IDC. The following keys are expected:
-  - role_arn: The ARN of the IAM role for the provisioner to assume which hass permissions to provision access in an AWS organization.
-  - idc_region: The AWS IDC Region.
-  - idc_instance_arn: The AWS Identity Center instance ARN.
-  - idc_identity_store_id: The AWS IAM Identity Center Identity Store ID.
-  EOF
-  type = object({
-    role_arn              = string
-    idc_region            = string
-    idc_instance_arn      = string
-    idc_identity_store_id = string
-  })
-  default = null
-}
-
-variable "provisioner_gcp_config" {
-  description = <<EOF
-  (Deprecated)
-  Configuration for GCP. The following keys are expected:
-  - service_account_client_json_ps_arn: (Optional) when using service account credentials, this is ARN of the secret credentials.
-  - workload_identity_config_json: (Optional) using Workload Identity Federation, this is the config file.
-
-  Either `workload_identity_config_json` or `service_account_client_json_ps_arn` must be provided (not both).
-  EOF
-  type = object({
-    service_account_client_json_ps_arn = optional(string)
-    workload_identity_config_json      = optional(string)
-  })
-  default = null
-}
-
-
-variable "provisioner_entra_config" {
-  description = <<EOF
-  (Deprecated)
-  Configuration for GCP. The following keys are expected:
-  - tenant_id: The Entra tenant ID.
-  - client_id: The client ID for the Entra App Registration.
-  - client_secret_secret_path: The SSM Parameter store secret path for the client secret for the Entra App Registration.
-  EOF
-  type = object({
-    tenant_id                 = string
-    client_id                 = string
-    client_secret_secret_path = string
-  })
-  default = null
-}
-
-
-variable "provisioner_aws_rds_config" {
-  description = <<EOF
-  (Deprecated)
-  Configuration for AWS RDS. The following keys are expected:
-  - idc_role_arn: The ARN of the IAM role for the provisioner to assume which hass permissions to provision access in an AWS organization.
-  - idc_region: The AWS IDC Region.
-  - idc_instance_arn: The AWS Identity Center instance ARN.
-  - infra_role_name: The name of the IAM role which is deployed each each account containing databases.
-  - should_provision_security_groups: (Optional) Whether or not the provisioner should attempt to provision security groups. Set this to true if you are not using pre deployed security groups.
-  EOF
-  type = object({
-    idc_role_arn                     = string
-    idc_region                       = string
-    idc_instance_arn                 = string
-    infra_role_name                  = string
-    should_provision_security_groups = optional(bool)
-  })
-  default = null
-}
-
-variable "provisioner_okta_config" {
-  description = <<EOF
-  (Deprecated)
-  Configuration for Okta. The following keys are expected:
-  - organization_id: The ID of your Okta organization.
-  - api_key_secret_path: The SSM Parameter store secret path for the api key for the Okta organization.
-  EOF
-  type = object({
-    organization_id     = string
-    api_key_secret_path = string
-  })
-  default = null
-}
-
-
-variable "provisioner_datastax_config" {
-  description = <<EOF
-  (Deprecated)
-  Configuration for DataStax. The following keys are expected:
-  - api_key_secret_path: The SSM Parameter store secret path for the api key for the DataStax organization.
-  EOF
-  type = object({
-    api_key_secret_path = string
-  })
-  default = null
-}
-
-
-variable "provisioner_auth0_config" {
-  description = <<EOF
-  (Deprecated)
-  Configuration for Auth0. The following keys are expected:
-  - domain: The Auth0 tenant domain.
-  - client_id: The Auth0 application client ID.
-  - client_secret_secret_path: The SSM Parameter store secret path for the Auth0 application client secret.
-  EOF
-  type = object({
-    domain                    = string
-    client_id                 = string
-    client_secret_secret_path = string
-  })
-  default = null
-}
-
-
-
-variable "unstable_enable_feature_least_privilege" {
-  type        = bool
-  default     = false
-  description = "Opt-in to enable Least Privilege Analytics (in early access). This variable will be removed once the feature is released."
-}
-
-variable "unstable_sync_idc_cloudtrail_schedule" {
-  type        = string
-  default     = "13 0 * * *"
-  description = "Least Privilege Analytics: the schedule to sync AWS CloudTrail events on"
-}
-
-variable "unstable_least_privilege_analysis_schedule" {
-  type        = string
-  default     = "13 5 * * *"
-  description = "Least Privilege Analytics: the schedule to build least privilege reports on"
-}
 
 variable "assume_role_external_id" {
   type        = string
@@ -418,11 +241,6 @@ variable "access_image_repository" {
   default     = "public.ecr.aws/z2x0a3a1/common-fate-deployment/access"
 }
 
-variable "authz_image_repository" {
-  type        = string
-  description = "Docker image repository to use for the Authz image"
-  default     = "public.ecr.aws/z2x0a3a1/common-fate-deployment/authz"
-}
 
 variable "provisioner_image_repository" {
   type        = string
@@ -435,9 +253,6 @@ variable "web_image_repository" {
   description = "Docker image repository to use for the Web image"
   default     = "public.ecr.aws/z2x0a3a1/common-fate-deployment/web"
 }
-
-
-
 
 
 variable "rds_db_retention_period" {
@@ -529,23 +344,12 @@ variable "factory_oidc_issuer" {
   default     = "https://factory.commonfate.io"
 }
 
-variable "unstable_feature_embedded_authorizations" {
-  type        = bool
-  default     = true
-  description = "Opt-in to enable Embedded Authorization (in early access). This variable will be removed once the feature is released."
-}
-
 variable "centralised_support" {
   type        = bool
   default     = true
   description = "Enable the in-app centralised support feature."
 }
 
-variable "force_rerun_config_migrations" {
-  type        = bool
-  description = "Whether to force the config migration to rerun on startup of the control plane"
-  default     = false
-}
 
 variable "database_auto_migrate" {
   type        = bool
@@ -553,8 +357,3 @@ variable "database_auto_migrate" {
   description = "Whether to run database migrations automatically when the Control Plane service starts. If rolling back to a previous release after a migration has run, set this to `false`."
 }
 
-variable "hierarchy_ui" {
-  type        = bool
-  default     = true
-  description = "Enable new hierarchy tree view to select entitlements."
-}


### PR DESCRIPTION
I have removed all of the deprecated variables to coincide with the new major version.

Teams have already migrated off of the provisioner and slack + pagerduty config in the previous releases and these variables were only left in as placeholders.

The least priv feature is also removed, and the hierarchy UI has been stabilised.