### PR TITLE
Josh/cf 3252 fix provisioner returning 504 gateway timeout v2

### DIFF
--- a/.changeset/good-jobs-sniff.md
+++ b/.changeset/good-jobs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fixes an issue in the Service Connect configuration which was causing a 15 second timeout. This would cause access requests to fail in some instances when multiple entitlements were requested.

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -395,7 +395,6 @@ resource "aws_ecs_service" "access_handler_service" {
         dns_name = "access.grpc"
       }
       timeout {
-        idle_timeout_seconds        = 60 * 3
         per_request_timeout_seconds = 60 * 3
       }
     }

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -394,6 +394,10 @@ resource "aws_ecs_service" "access_handler_service" {
         port     = 9090
         dns_name = "access.grpc"
       }
+      timeout {
+        idle_timeout_seconds        = 60 * 3
+        per_request_timeout_seconds = 60 * 3
+      }
     }
   }
 }

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -773,6 +773,9 @@ resource "aws_ecs_service" "control_plane_service" {
     enabled   = true
     namespace = var.service_discovery_namespace_arn
 
+
+    // named with v2 because we needed to recreate the address to fix a timeout issue
+    // we don;t currently make calls directly to the control plane, if we start doing that, we could change this back to drop the v2 suffix
     service {
       discovery_name = "control_plane-grpc-v2"
       port_name      = "control_plane"

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -632,6 +632,7 @@ resource "aws_ecs_task_definition" "control_plane_task" {
       portMappings = [{
         containerPort = 8080,
         name          = "control_plane"
+        appProtocol   = "http"
       }],
 
       environment = local.control_plane_environment
@@ -771,15 +772,15 @@ resource "aws_ecs_service" "control_plane_service" {
   service_connect_configuration {
     enabled   = true
     namespace = var.service_discovery_namespace_arn
+
     service {
-      discovery_name = "control_plane-grpc"
+      discovery_name = "control_plane-grpc-v2"
       port_name      = "control_plane"
       client_alias {
         port     = 8080
-        dns_name = "control_plane.grpc"
+        dns_name = "control_plane_v2.grpc"
       }
       timeout {
-        idle_timeout_seconds        = 60 * 3
         per_request_timeout_seconds = 60 * 3
       }
     }

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -778,6 +778,10 @@ resource "aws_ecs_service" "control_plane_service" {
         port     = 8080
         dns_name = "control_plane.grpc"
       }
+      timeout {
+        idle_timeout_seconds        = 60 * 3
+        per_request_timeout_seconds = 60 * 3
+      }
     }
   }
 
@@ -917,6 +921,7 @@ resource "aws_ecs_service" "worker_service" {
   service_connect_configuration {
     enabled   = true
     namespace = var.service_discovery_namespace_arn
+
   }
 
   network_configuration {

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -632,7 +632,6 @@ resource "aws_ecs_task_definition" "control_plane_task" {
       portMappings = [{
         containerPort = 8080,
         name          = "control_plane"
-        appProtocol   = "http"
       }],
 
       environment = local.control_plane_environment
@@ -774,17 +773,12 @@ resource "aws_ecs_service" "control_plane_service" {
     namespace = var.service_discovery_namespace_arn
 
 
-    // named with v2 because we needed to recreate the address to fix a timeout issue
-    // we don’t currently make calls directly to the control plane, if we start doing that, we could change this back to drop the v2 suffix
     service {
-      discovery_name = "control_plane-grpc-v2"
+      discovery_name = "control_plane-grpc"
       port_name      = "control_plane"
       client_alias {
         port     = 8080
-        dns_name = "control_plane_v2.grpc"
-      }
-      timeout {
-        per_request_timeout_seconds = 60 * 3
+        dns_name = "control_plane.grpc"
       }
     }
   }

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -775,7 +775,7 @@ resource "aws_ecs_service" "control_plane_service" {
 
 
     // named with v2 because we needed to recreate the address to fix a timeout issue
-    // we don;t currently make calls directly to the control plane, if we start doing that, we could change this back to drop the v2 suffix
+    // we don’t currently make calls directly to the control plane, if we start doing that, we could change this back to drop the v2 suffix
     service {
       discovery_name = "control_plane-grpc-v2"
       port_name      = "control_plane"


### PR DESCRIPTION
Fixes timeout errors when requesting access.

Service connect imposes a default 15s timeout when it is enabled. https://aws.amazon.com/about-aws/whats-new/2024/01/amazon-ecs-configurable-timeout-service-connect/

This also affects ALB to service connections which is the root cause of the timeout bug see report here https://github.com/aws/containers-roadmap/issues/1958#issuecomment-1641952886