### PR TITLE
add Terraform variables for CLI token duration

### DIFF
--- a/.changeset/stupid-llamas-call.md
+++ b/.changeset/stupid-llamas-call.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+For BYOC customers: adds Terraform variables to configure the access and refresh token duration for the CLI client.

--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,10 @@ module "cognito" {
   web_access_token_validity_units     = var.web_access_token_validity_units
   web_refresh_token_validity_duration = var.web_refresh_token_validity_duration
   web_refresh_token_validity_units    = var.web_refresh_token_validity_units
+  cli_access_token_validity_duration  = var.cli_access_token_validity_duration
+  cli_access_token_validity_units     = var.cli_access_token_validity_units
+  cli_refresh_token_validity_duration = var.cli_refresh_token_validity_duration
+  cli_refresh_token_validity_units    = var.cli_refresh_token_validity_units
 }
 
 

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -97,6 +97,12 @@ resource "aws_cognito_user_pool_client" "cli_client" {
   callback_urls                        = ["http://localhost:18900/auth/callback"]
   depends_on                           = [aws_cognito_identity_provider.saml_idp]
 
+  access_token_validity  = var.cli_access_token_validity_duration
+  refresh_token_validity = var.cli_refresh_token_validity_duration
+  token_validity_units {
+    access_token  = var.cli_access_token_validity_units
+    refresh_token = var.cli_refresh_token_validity_units
+  }
 }
 
 

--- a/modules/cognito/variables.tf
+++ b/modules/cognito/variables.tf
@@ -52,13 +52,13 @@ variable "saml_metadata_source" {
 }
 
 variable "web_access_token_validity_duration" {
-  description = "Specifies how long the access token in the web cognito client will be valid for. Unit is specified in `web_oidc_token_validity_units` and is in minutes by default."
+  description = "Specifies how long the access token in the web Cognito client will be valid for. Unit is specified in `web_oidc_token_validity_units` and is in minutes by default."
   default     = 10
   type        = number
 }
 
 variable "web_refresh_token_validity_duration" {
-  description = "Specifies how long the refresh token in the web cognito client will be valid for.  Unit is specified in `web_oidc_token_validity_units` and is in days by default."
+  description = "Specifies how long the refresh token in the web Cognito client will be valid for.  Unit is specified in `web_oidc_token_validity_units` and is in days by default."
   default     = 30
   type        = number
 }
@@ -69,6 +69,28 @@ variable "web_access_token_validity_units" {
 }
 
 variable "web_refresh_token_validity_units" {
-  description = "Specifies the duration unit used for the 'web_access_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  description = "Specifies the duration unit used for the 'web_refresh_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "days"
+}
+
+variable "cli_access_token_validity_duration" {
+  description = "Specifies how long the access token in the CLI Cognito client will be valid for. Unit is specified in `web_oidc_token_validity_units` and is in minutes by default."
+  default     = 60
+  type        = number
+}
+
+variable "cli_refresh_token_validity_duration" {
+  description = "Specifies how long the refresh token in the CLI Cognito client will be valid for.  Unit is specified in `web_oidc_token_validity_units` and is in days by default."
+  default     = 30
+  type        = number
+}
+
+variable "cli_access_token_validity_units" {
+  description = "Specifies the duration unit used for the 'cli_access_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "minutes"
+}
+
+variable "cli_refresh_token_validity_units" {
+  description = "Specifies the duration unit used for the 'cli_refresh_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
   default     = "days"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -346,3 +346,25 @@ variable "database_auto_migrate" {
   default     = true
   description = "Whether to run database migrations automatically when the Control Plane service starts. If rolling back to a previous release after a migration has run, set this to `false`."
 }
+
+variable "cli_access_token_validity_duration" {
+  description = "Specifies how long the access token in the CLI Cognito client will be valid for. Unit is specified in `web_oidc_token_validity_units` and is in minutes by default."
+  default     = 60
+  type        = number
+}
+
+variable "cli_refresh_token_validity_duration" {
+  description = "Specifies how long the refresh token in the CLI Cognito client will be valid for.  Unit is specified in `web_oidc_token_validity_units` and is in days by default."
+  default     = 30
+  type        = number
+}
+
+variable "cli_access_token_validity_units" {
+  description = "Specifies the duration unit used for the 'cli_access_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "minutes"
+}
+
+variable "cli_refresh_token_validity_units" {
+  description = "Specifies the duration unit used for the 'cli_refresh_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
+  default     = "days"
+}


### PR DESCRIPTION
Similar to the existing `web_access_token_validity_duration` etc.
