### PR TITLE
Expose cpu and memory variables for the ecs services

### DIFF
--- a/.changeset/tall-paws-share.md
+++ b/.changeset/tall-paws-share.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Exposes ecs_task_memory and ecs_task_cpu variables for the control plane, workder and access handler services.

--- a/main.tf
+++ b/main.tf
@@ -205,6 +205,10 @@ module "control_plane" {
   oidc_read_only_client_id               = module.cognito.read_only_client_id
   usage_reporting_enabled                = var.usage_reporting_enabled
   usage_reporting_interval               = var.usage_reporting_interval
+  ecs_task_cpu                           = var.control_plane_ecs_task_cpu
+  ecs_task_memory                        = var.control_plane_ecs_task_memory
+  worker_ecs_task_cpu                    = var.worker_ecs_task_cpu
+  worker_ecs_task_memory                 = var.worker_ecs_task_memory
 }
 
 
@@ -291,6 +295,8 @@ module "access_handler" {
   managed_monitoring_endpoint               = var.managed_monitoring_endpoint
   factory_base_url                          = var.factory_base_url
   factory_oidc_issuer                       = var.factory_oidc_issuer
+  ecs_task_cpu                              = var.access_handler_ecs_task_cpu
+  ecs_task_memory                           = var.access_hander_ecs_task_memory
 }
 
 

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -73,13 +73,13 @@ variable "log_retention_in_days" {
 variable "ecs_task_cpu" {
   description = "The amount of CPU to allocate for the ECS task. Specified in CPU units (1024 units = 1 vCPU)."
   type        = string
-  default     = "256" # Example default, adjust as needed
+  default     = "512"
 }
 
 variable "ecs_task_memory" {
   description = "The amount of memory to allocate for the ECS task. Specified in MiB."
   type        = string
-  default     = "512" # Example default, adjust as needed
+  default     = "1024"
 }
 variable "desired_task_count" {
   description = "The desired number of instances of the task to run."

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -686,8 +686,8 @@ resource "aws_ecs_task_definition" "worker_task" {
   family                   = "${var.namespace}-${var.stage}-worker"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = var.ecs_worker_task_cpu
-  memory                   = var.ecs_worker_task_memory
+  cpu                      = var.worker_ecs_task_cpu
+  memory                   = var.worker_ecs_task_memory
   execution_role_arn       = aws_iam_role.control_plane_ecs_execution_role.arn
   task_role_arn            = aws_iam_role.control_plane_ecs_task_role.arn
 

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -154,13 +154,13 @@ variable "desired_task_count" {
   default     = 1
 }
 
-variable "ecs_worker_task_cpu" {
+variable "worker_ecs_task_cpu" {
   description = "The amount of CPU to allocate for the ECS worker task. Specified in CPU units (1024 units = 1 vCPU)."
   type        = string
   default     = "512" # Example default, adjust as needed
 }
 
-variable "ecs_worker_task_memory" {
+variable "worker_ecs_task_memory" {
   description = "The amount of memory to allocate for the ECS task. Specified in MiB."
   type        = string
   default     = "1024" # Example default, adjust as needed

--- a/variables.tf
+++ b/variables.tf
@@ -380,3 +380,39 @@ variable "cli_refresh_token_validity_units" {
   description = "Specifies the duration unit used for the 'cli_refresh_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
   default     = "days"
 }
+
+variable "control_plane_ecs_task_memory" {
+  description = "The amount of memory to allocate for the ECS task. Specified in MiB."
+  type        = string
+  default     = "1024"
+}
+
+variable "control_plane_ecs_task_cpu" {
+  description = "The amount of CPU to allocate for the ECS task. Specified in CPU units (1024 units = 1 vCPU)."
+  type        = string
+  default     = "512"
+}
+
+variable "worker_ecs_task_memory" {
+  description = "The amount of memory to allocate for the ECS task. Specified in MiB."
+  type        = string
+  default     = "1024"
+}
+
+variable "worker_ecs_task_cpu" {
+  description = "The amount of CPU to allocate for the ECS task. Specified in CPU units (1024 units = 1 vCPU)."
+  type        = string
+  default     = "512"
+}
+
+variable "access_hander_ecs_task_memory" {
+  description = "The amount of memory to allocate for the ECS task. Specified in MiB."
+  type        = string
+  default     = "1024"
+}
+
+variable "access_handler_ecs_task_cpu" {
+  description = "The amount of CPU to allocate for the ECS task. Specified in CPU units (1024 units = 1 vCPU)."
+  type        = string
+  default     = "512"
+}


### PR DESCRIPTION
Adds variabels to the main module to configure the Access Handler, Control Plane and Worker

Also bumps the defaults for the access handler up to 512/1024