### PR TITLE
Enable Managed Monitoring by default

### DIFF
--- a/.changeset/hungry-crabs-join.md
+++ b/.changeset/hungry-crabs-join.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Managed Monitoring for deployments is now enabled by default (https://docs.commonfate.io/setup/managed-monitoring).

--- a/variables.tf
+++ b/variables.tf
@@ -338,7 +338,7 @@ variable "usage_reporting_interval" {
 variable "managed_monitoring_enabled" {
   description = "Enables Managed Monitoring for the deployment."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "managed_monitoring_endpoint" {


### PR DESCRIPTION
We've been running managed monitoring now on multiple deployments in production for a few months.
It is a sensible default to enable because it allows Common Fate to proactively detect issues with deployments and monitor performance.
