### PR TITLE
Add new vpc name configuration

### DIFF
--- a/.changeset/yellow-ears-taste.md
+++ b/.changeset/yellow-ears-taste.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": major
+---
+
+Change the default VPC name for new deployments to include the namespace and stage params. In pre v3.0.0 the vpc was mistakingly created with a fixed name, this prevents multiple deployments being provisioned in the same AWS account. To fix this, a new variable has been added use_pre_3_0_0_vpc_name which shoudl be set to true for all existing deployments before upgrading to the new version.

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ module "vpc" {
   aws_region             = var.aws_region
   one_nat_gateway_per_az = var.one_nat_gateway_per_az
   single_nat_gateway     = var.single_nat_gateway
+  use_pre_3_0_0_vpc_name = var.use_pre_3_0_0_vpc_name
 }
 
 module "alb" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -9,7 +9,7 @@ locals {
   // in our original stack, the vpc was mistakingly named without the namespace and stage
   // we need the stage so that multiple deployments in the same account are possible
   // the check instends to discover whether the vpc is already deployed, if it is, it means that it has the 
-  vpc_name = var.use_pre_3_0_0_vpc_name ? "common-fate" : "${var.namespace}-${var.stage}-vpc"
+  vpc_name = var.use_pre_3_0_0_vpc_name ? "common_fate" : "${var.namespace}-${var.stage}-vpc"
 }
 
 module "vpc" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -2,11 +2,21 @@
 # Networking
 ######################################################
 
+
+
+
+locals {
+  // in our original stack, the vpc was mistakingly named without the namespace and stage
+  // we need the stage so that multiple deployments in the same account are possible
+  // the check instends to discover whether the vpc is already deployed, if it is, it means that it has the 
+  vpc_name = var.use_pre_3_0_0_vpc_name ? "common-fate" : "${var.namespace}-${var.stage}-vpc"
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.1.1"
 
-  name                         = "common_fate"
+  name                         = local.vpc_name
   cidr                         = "10.0.0.0/17"
   azs                          = ["${var.aws_region}a", "${var.aws_region}b", "${var.aws_region}c"]
   public_subnets               = ["10.0.0.0/21", "10.0.8.0/21", "10.0.16.0/21"]
@@ -17,6 +27,8 @@ module "vpc" {
   enable_nat_gateway           = true
   single_nat_gateway           = var.single_nat_gateway
   one_nat_gateway_per_az       = var.one_nat_gateway_per_az
+
+
 }
 
 resource "aws_vpc_endpoint" "s3" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -26,3 +26,8 @@ variable "one_nat_gateway_per_az" {
   default     = true
   description = "Should be false if you want to provision a single shared NAT Gateway for the deployment."
 }
+
+variable "use_pre_3_0_0_vpc_name" {
+  default     = false
+  description = "Whether to use the original VPC name common-fate which is required for all deployments which were created pre 3.0.0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -441,3 +441,8 @@ variable "access_handler_ecs_task_cpu" {
   type        = string
   default     = "512"
 }
+
+variable "use_pre_3_0_0_vpc_name" {
+  default     = false
+  description = "Whether to use the original VPC name common-fate which is required for all deployments which were created pre 3.0.0"
+}


### PR DESCRIPTION
This is marked as a major version change because it requires all existing deployments to add the new variable to prevent their VPC being replaced

We will need a migration guide for this and to inform each customer of the requirement to add 

  use_pre_3_0_0_vpc_name = true
  
  An alternative to this PR which is non breaking would be to add a variable `vpc_name_suffix` which we can configure to be the "stage" in cases where we need to deploy multiple.
  
 This means customers don't need to do anything but its not a perfect long term solution
 
 Here is the alternative PR https://github.com/common-fate/terraform-aws-common-fate-deployment/pull/290