### PR TITLE
Add initial user emails invite mechanism

### DIFF
--- a/.changeset/red-sheep-battle.md
+++ b/.changeset/red-sheep-battle.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+Adds support for inviting an initial set of users to Common Fate when Cognito is used as the login provider. initial_user_emails is a comma seperated list of emails which will be created in Cognito and have an initial invite email sent.

--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,7 @@ module "cognito" {
   cli_access_token_validity_units     = var.cli_access_token_validity_units
   cli_refresh_token_validity_duration = var.cli_refresh_token_validity_duration
   cli_refresh_token_validity_units    = var.cli_refresh_token_validity_units
+  initial_user_emails                 = var.initial_user_emails
 }
 
 

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -238,3 +238,19 @@ resource "aws_cognito_user_pool_domain" "custom_domain" {
   user_pool_id    = aws_cognito_user_pool.cognito_user_pool.id
   certificate_arn = local.has_custom_domain ? var.auth_certificate_arn : null
 }
+
+
+locals {
+  // the initial users to create is a comma seperated list, split and trim any whitespace
+  initial_user_emails = toset([for email in split(",", var.initial_user_emails) : trim(email, " ")])
+}
+resource "aws_cognito_user" "initial_users" {
+  for_each     = local.initial_user_emails
+  user_pool_id = aws_cognito_user_pool.cognito_user_pool.id
+  username     = each.value
+  attributes = {
+    email = each.value
+  }
+  // send notifications via email only
+  desired_delivery_mediums = ["EMAIL"]
+}

--- a/modules/cognito/variables.tf
+++ b/modules/cognito/variables.tf
@@ -94,3 +94,8 @@ variable "cli_refresh_token_validity_units" {
   description = "Specifies the duration unit used for the 'cli_refresh_token_validity_duration' variable. Valid values are seconds, minutes, hours or days."
   default     = "days"
 }
+variable "initial_user_emails" {
+  description = "Comma separated list of user emails to create in Cognito for the initial deployment, an invite email will be sent with details for logging in."
+  default     = ""
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -441,3 +441,9 @@ variable "access_handler_ecs_task_cpu" {
   type        = string
   default     = "512"
 }
+
+variable "initial_user_emails" {
+  description = "Comma separated list of user emails to create in Cognito for the initial deployment, an invite email will be sent with details for logging in."
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
The list of emails can be provided and users will be created in Cognito, an invite email will be send which contains a password and instructions to login