### PR TITLE
Remove `aws` provider block from the module

### DIFF
--- a/.changeset/large-years-chew.md
+++ b/.changeset/large-years-chew.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Removes the hardcoded AWS provider block in the module. Fixes an issue where the module could not be destroyed due to the provider block being present.

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,10 @@
-provider "aws" {
-  region = var.aws_region
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
 }
 
 data "aws_partition" "current" {}


### PR DESCRIPTION
Removes the hardcoded AWS provider block in the module. Fixes an issue where the module could not be destroyed due to the provider block being present.