### PR TITLE
Configurable target groups

### DIFF
--- a/.changeset/sixty-icons-compare.md
+++ b/.changeset/sixty-icons-compare.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Makes target groups to ECS services configurable, allowing additional load balancers to be added to a Common Fate deployment.

--- a/main.tf
+++ b/main.tf
@@ -229,6 +229,8 @@ module "control_plane" {
   read_only_service_client_secret        = module.cognito.read_only_client_secret
   factory_monitoring                     = var.factory_monitoring
   administrator_emails                   = var.administrator_emails
+  additional_target_groups               = var.control_plane_target_group_arns
+  additional_target_groups_http2         = var.control_plane_target_group_arns_http_2
 }
 
 module "report_bucket" {
@@ -316,6 +318,7 @@ module "access_handler" {
   factory_oidc_issuer                       = var.factory_oidc_issuer
   ecs_task_cpu                              = var.access_handler_ecs_task_cpu
   ecs_task_memory                           = var.access_hander_ecs_task_memory
+  additional_target_groups                  = var.access_target_group_arns
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,6 @@ locals {
   private_subnet_ids       = var.vpc_id != null ? var.private_subnet_ids : module.vpc[0].private_subnet_ids
   database_subnet_group_id = var.vpc_id != null ? var.database_subnet_group_id : module.vpc[0].database_subnet_group_id
   ecs_cluster_id           = var.ecs_cluster_id != null ? var.ecs_cluster_id : module.ecs[0].cluster_id
-
 }
 
 moved {

--- a/main.tf
+++ b/main.tf
@@ -253,25 +253,26 @@ module "authz_eval_bucket" {
 
 
 module "web" {
-  source                = "./modules/web"
-  namespace             = var.namespace
-  stage                 = var.stage
-  aws_region            = var.aws_region
-  aws_account_id        = data.aws_caller_identity.current.account_id
-  release_tag           = var.release_tag
-  subnet_ids            = local.private_subnet_ids
-  vpc_id                = local.vpc_id
-  auth_authority_url    = module.cognito.auth_authority_url
-  auth_cli_client_id    = module.cognito.cli_client_id
-  auth_url              = module.cognito.auth_url
-  auth_web_client_id    = module.cognito.web_client_id
-  ecs_cluster_id        = local.ecs_cluster_id
-  alb_listener_arn      = module.alb.listener_arn
-  app_url               = var.app_url
-  auth_issuer           = module.cognito.auth_issuer
-  alb_security_group_id = module.alb.alb_security_group_id
-  web_image_repository  = var.web_image_repository
-  centralised_support   = var.centralised_support
+  source                   = "./modules/web"
+  namespace                = var.namespace
+  stage                    = var.stage
+  aws_region               = var.aws_region
+  aws_account_id           = data.aws_caller_identity.current.account_id
+  release_tag              = var.release_tag
+  subnet_ids               = local.private_subnet_ids
+  vpc_id                   = local.vpc_id
+  auth_authority_url       = module.cognito.auth_authority_url
+  auth_cli_client_id       = module.cognito.cli_client_id
+  auth_url                 = module.cognito.auth_url
+  auth_web_client_id       = module.cognito.web_client_id
+  ecs_cluster_id           = local.ecs_cluster_id
+  alb_listener_arn         = module.alb.listener_arn
+  app_url                  = var.app_url
+  auth_issuer              = module.cognito.auth_issuer
+  alb_security_group_id    = module.alb.alb_security_group_id
+  web_image_repository     = var.web_image_repository
+  centralised_support      = var.centralised_support
+  additional_target_groups = var.web_target_group_arns
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,7 @@ module "control_plane" {
   read_only_service_client_secret        = module.cognito.read_only_client_secret
   factory_monitoring                     = var.factory_monitoring
   administrator_emails                   = var.administrator_emails
-  additional_target_groups               = var.control_plane_target_group_arns
+  control_plane_target_group_arns        = var.control_plane_target_group_arns
 }
 
 module "report_bucket" {
@@ -254,26 +254,26 @@ module "authz_eval_bucket" {
 
 
 module "web" {
-  source                   = "./modules/web"
-  namespace                = var.namespace
-  stage                    = var.stage
-  aws_region               = var.aws_region
-  aws_account_id           = data.aws_caller_identity.current.account_id
-  release_tag              = var.release_tag
-  subnet_ids               = local.private_subnet_ids
-  vpc_id                   = local.vpc_id
-  auth_authority_url       = module.cognito.auth_authority_url
-  auth_cli_client_id       = module.cognito.cli_client_id
-  auth_url                 = module.cognito.auth_url
-  auth_web_client_id       = module.cognito.web_client_id
-  ecs_cluster_id           = local.ecs_cluster_id
-  alb_listener_arn         = module.alb.listener_arn
-  app_url                  = var.app_url
-  auth_issuer              = module.cognito.auth_issuer
-  alb_security_group_id    = module.alb.alb_security_group_id
-  web_image_repository     = var.web_image_repository
-  centralised_support      = var.centralised_support
-  additional_target_groups = var.web_target_group_arns
+  source                = "./modules/web"
+  namespace             = var.namespace
+  stage                 = var.stage
+  aws_region            = var.aws_region
+  aws_account_id        = data.aws_caller_identity.current.account_id
+  release_tag           = var.release_tag
+  subnet_ids            = local.private_subnet_ids
+  vpc_id                = local.vpc_id
+  auth_authority_url    = module.cognito.auth_authority_url
+  auth_cli_client_id    = module.cognito.cli_client_id
+  auth_url              = module.cognito.auth_url
+  auth_web_client_id    = module.cognito.web_client_id
+  ecs_cluster_id        = local.ecs_cluster_id
+  alb_listener_arn      = module.alb.listener_arn
+  app_url               = var.app_url
+  auth_issuer           = module.cognito.auth_issuer
+  alb_security_group_id = module.alb.alb_security_group_id
+  web_image_repository  = var.web_image_repository
+  centralised_support   = var.centralised_support
+  web_target_group_arns = var.web_target_group_arns
 }
 
 
@@ -317,7 +317,7 @@ module "access_handler" {
   factory_oidc_issuer                       = var.factory_oidc_issuer
   ecs_task_cpu                              = var.access_handler_ecs_task_cpu
   ecs_task_memory                           = var.access_hander_ecs_task_memory
-  additional_target_groups                  = var.access_target_group_arns
+  access_target_group_arns                  = var.access_target_group_arns
 }
 
 

--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,6 @@ module "control_plane" {
   factory_monitoring                     = var.factory_monitoring
   administrator_emails                   = var.administrator_emails
   additional_target_groups               = var.control_plane_target_group_arns
-  additional_target_groups_http2         = var.control_plane_target_group_arns_http_2
 }
 
 module "report_bucket" {

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -1,4 +1,8 @@
 
+locals {
+  access_target_group_arns = var.additional_target_groups != [] ? concat([aws_lb_target_group.access_handler_tg.arn], var.additional_target_groups) : [aws_lb_target_group.access_handler_tg.arn]
+}
+
 #trivy:ignore:AVD-AWS-0104
 resource "aws_security_group" "ecs_access_handler_sg_v2" {
   name        = "${var.namespace}-${var.stage}-access-handler"
@@ -377,10 +381,13 @@ resource "aws_ecs_service" "access_handler_service" {
     security_groups = [aws_security_group.ecs_access_handler_sg_v2.id]
   }
 
-  load_balancer {
-    target_group_arn = aws_lb_target_group.access_handler_tg.arn
-    container_name   = "access-handler-container"
-    container_port   = 9090
+  dynamic "load_balancer" {
+    for_each = toset(local.access_target_group_arns)
+    content {
+      target_group_arn = load_balancer.value
+      container_name   = "access-handler-container"
+      container_port   = 9090
+    }
   }
 
   deployment_circuit_breaker {

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -1,6 +1,6 @@
 
 locals {
-  access_target_group_arns = var.additional_target_groups != [] ? concat([aws_lb_target_group.access_handler_tg.arn], var.additional_target_groups) : [aws_lb_target_group.access_handler_tg.arn]
+  access_target_group_arns = var.access_target_group_arns != [] ? concat([aws_lb_target_group.access_handler_tg.arn], var.access_target_group_arns) : [aws_lb_target_group.access_handler_tg.arn]
 }
 
 #trivy:ignore:AVD-AWS-0104

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -225,7 +225,7 @@ variable "factory_monitoring" {
   default     = true
 }
 
-variable "additional_target_groups" {
+variable "access_target_group_arns" {
   type        = list(string)
   description = "Additional target groups to attach the service to."
   default     = []

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -224,3 +224,9 @@ variable "factory_monitoring" {
   type        = bool
   default     = true
 }
+
+variable "additional_target_groups" {
+  type        = list(string)
+  description = "Additional target groups to attach the service to."
+  default     = []
+}

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -4,7 +4,7 @@
 ######################################################
 
 locals {
-  control_plane_target_groups = var.additional_target_groups != [] ? concat([aws_lb_target_group.control_plane_tg.arn, aws_lb_target_group.control_plane_tg_http2.arn], var.additional_target_groups) : [aws_lb_target_group.control_plane_tg.arn, aws_lb_target_group.control_plane_tg_http2.arn]
+  control_plane_target_groups = var.control_plane_target_group_arns != [] ? concat([aws_lb_target_group.control_plane_tg.arn, aws_lb_target_group.control_plane_tg_http2.arn], var.control_plane_target_group_arns) : [aws_lb_target_group.control_plane_tg.arn, aws_lb_target_group.control_plane_tg_http2.arn]
 }
 
 #trivy:ignore:AVD-AWS-0104

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -3,6 +3,10 @@
 # Control Plane
 ######################################################
 
+locals {
+  control_plane_target_groups = var.additional_target_groups != [] ? concat([aws_lb_target_group.control_plane_tg.arn, aws_lb_target_group.control_plane_tg_http2.arn], var.additional_target_groups) : [aws_lb_target_group.control_plane_tg.arn, aws_lb_target_group.control_plane_tg_http2.arn]
+}
+
 #trivy:ignore:AVD-AWS-0104
 resource "aws_security_group" "ecs_control_plane_sg_v2" {
   name        = "${var.namespace}-${var.stage}-control-plane"
@@ -867,17 +871,16 @@ resource "aws_ecs_service" "control_plane_service" {
     assign_public_ip = true
   }
 
-  load_balancer {
-    target_group_arn = aws_lb_target_group.control_plane_tg.arn
-    container_name   = "control-plane-container"
-    container_port   = 8080
+  dynamic "load_balancer" {
+    for_each = local.control_plane_target_groups
+
+    content {
+      target_group_arn = load_balancer.value
+      container_name   = "control-plane-container"
+      container_port   = 8080
+    }
   }
 
-  load_balancer {
-    target_group_arn = aws_lb_target_group.control_plane_tg_http2.arn
-    container_name   = "control-plane-container"
-    container_port   = 8080
-  }
 }
 
 resource "aws_lb_listener_rule" "service_rule" {

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -393,7 +393,7 @@ variable "administrator_emails" {
   type        = list(string)
 }
 
-variable "additional_target_groups" {
+variable "control_plane_target_group_arns" {
   type        = list(string)
   description = "Additional target groups to attach the service to."
   default     = []

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -392,3 +392,9 @@ variable "administrator_emails" {
   default     = []
   type        = list(string)
 }
+
+variable "additional_target_groups" {
+  type        = list(string)
+  description = "Additional target groups to attach the service to."
+  default     = []
+}

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -182,7 +182,7 @@ resource "aws_ecs_service" "web_service" {
   dynamic "load_balancer" {
     for_each = toset(local.web_target_group_arns)
     content {
-      target_group_arn = each.value
+      target_group_arn = load_balancer.value
       container_name   = "web_container"
       container_port   = 80
     }

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -179,11 +179,13 @@ resource "aws_ecs_service" "web_service" {
     security_groups = [aws_security_group.ecs_web_sg_v2.id]
   }
 
-  load_balancer {
+  dynamic "load_balancer" {
     for_each = toset(local.web_target_group_arns)
-    target_group_arn = each.value
-    container_name   = "web_container"
-    container_port   = 80
+    content {
+      target_group_arn = each.value
+      container_name   = "web_container"
+      container_port   = 80
+    }
   }
 }
 resource "aws_lb_listener_rule" "service_rule" {

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -180,7 +180,8 @@ resource "aws_ecs_service" "web_service" {
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.web_tg.arn
+    for_each = toset(local.web_target_group_arns)
+    target_group_arn = each.value
     container_name   = "web_container"
     container_port   = 80
   }
@@ -199,4 +200,7 @@ resource "aws_lb_listener_rule" "service_rule" {
     }
   }
 
+}
+locals {
+  web_target_group_arns = var.additional_target_groups != [] ? concat([aws_lb_target_group.web_tg.arn], var.additional_target_groups) : [aws_lb_target_group.web_tg.arn]
 }

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -204,5 +204,5 @@ resource "aws_lb_listener_rule" "service_rule" {
 
 }
 locals {
-  web_target_group_arns = var.additional_target_groups != [] ? concat([aws_lb_target_group.web_tg.arn], var.additional_target_groups) : [aws_lb_target_group.web_tg.arn]
+  web_target_group_arns = var.web_target_group_arns != [] ? concat([aws_lb_target_group.web_tg.arn], var.web_target_group_arns) : [aws_lb_target_group.web_tg.arn]
 }

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -156,7 +156,7 @@ variable "hierarchy_ui" {
 
 }
 
-variable "additional_target_groups" {
+variable "web_target_group_arns" {
   type        = list(string)
   description = "Additional target groups to attach the service to."
   default     = []

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -155,3 +155,9 @@ variable "hierarchy_ui" {
   description = "Enable new hierarchy tree view to select entitlements."
 
 }
+
+variable "additional_target_groups" {
+  type        = list(string)
+  description = "Additional target groups to attach the service to."
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -456,7 +456,25 @@ variable "administrator_emails" {
 }
 
 variable "web_target_group_arns" {
-  description = "ARN of supplemental target groups for the web service."
+  description = "ARNs of supplemental target groups for the web service."
+  default = []
+  type = list(string)
+}
+
+variable "access_target_group_arns" {
+  description = "ARNs of supplemental target groups for the access handler service."
+  default = []
+  type = list(string)
+}
+
+variable "control_plane_target_group_arns" {
+  description = "ARNs of supplemental target groups for the control plane service."
+  default = []
+  type = list(string)
+}
+
+variable "control_plane_target_group_arns_http_2" {
+  description = "ARNs of supplemental target groups for the control plane service that support HTTP/2."
   default = []
   type = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -454,3 +454,11 @@ variable "administrator_emails" {
   default     = []
   type        = list(string)
 }
+
+variable "web_target_group_arns" {
+  description = "ARN of supplemental target groups for the web service."
+  default = []
+  type list(string)
+}
+
+variable ""

--- a/variables.tf
+++ b/variables.tf
@@ -458,7 +458,5 @@ variable "administrator_emails" {
 variable "web_target_group_arns" {
   description = "ARN of supplemental target groups for the web service."
   default = []
-  type list(string)
+  type = list(string)
 }
-
-variable ""

--- a/variables.tf
+++ b/variables.tf
@@ -472,9 +472,3 @@ variable "control_plane_target_group_arns" {
   default = []
   type = list(string)
 }
-
-variable "control_plane_target_group_arns_http_2" {
-  description = "ARNs of supplemental target groups for the control plane service that support HTTP/2."
-  default = []
-  type = list(string)
-}


### PR DESCRIPTION
Makes target groups to ECS services configurable, allowing additional load balancers to be added to a Common Fate deployment.