### PR TITLE
Pass builtin provisioner url to the services

### DIFF
--- a/.changeset/odd-mails-repair.md
+++ b/.changeset/odd-mails-repair.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Add managed_deployment variable to apply additional configuration on initial deployment.

--- a/.changeset/warm-panthers-visit.md
+++ b/.changeset/warm-panthers-visit.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Pass in the builtin provisioner webhook url to the Control Plane and Access Handler services.

--- a/main.tf
+++ b/main.tf
@@ -232,6 +232,8 @@ module "control_plane" {
   factory_monitoring                     = var.factory_monitoring
   administrator_emails                   = var.administrator_emails
   control_plane_target_group_arns        = var.control_plane_target_group_arns
+  builtin_provisioner_url                = module.provisioner.provisioner_url
+  managed_deployment                     = var.managed_deployment
 }
 
 module "report_bucket" {
@@ -320,6 +322,7 @@ module "access_handler" {
   ecs_task_cpu                              = var.access_handler_ecs_task_cpu
   ecs_task_memory                           = var.access_hander_ecs_task_memory
   access_target_group_arns                  = var.access_target_group_arns
+  builtin_provisioner_url                   = module.provisioner.provisioner_url
 }
 
 

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -306,6 +306,10 @@ resource "aws_ecs_task_definition" "access_handler_task" {
           name  = "CF_FACTORY_MONITORING",
           value = var.factory_monitoring ? "true" : "false"
         },
+        {
+          name  = "CF_BUILTIN_WEBHOOK_PROVISIONER_URL",
+          value = var.builtin_provisioner_url
+        },
       ],
       secrets = [
         {

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -230,3 +230,8 @@ variable "access_target_group_arns" {
   description = "Additional target groups to attach the service to."
   default     = []
 }
+
+variable "builtin_provisioner_url" {
+  description = "The URL of the builtin provisioner."
+  type        = string
+}

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -678,7 +678,14 @@ locals {
       name  = "CF_ADMINISTRATORS",
       value = join(",", var.administrator_emails)
     },
-
+    {
+      name  = "CF_BUILTIN_WEBHOOK_PROVISIONER_URL",
+      value = var.builtin_provisioner_url
+    },
+    {
+      name  = "CF_MANAGED_DEPLOYMENT",
+      value = var.managed_deployment
+    },
   ]
 
   // Only add these secrets if their values are provided

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -398,3 +398,16 @@ variable "control_plane_target_group_arns" {
   description = "Additional target groups to attach the service to."
   default     = []
 }
+
+
+variable "builtin_provisioner_url" {
+  description = "The URL of the builtin provisioner."
+  type        = string
+}
+
+
+variable "managed_deployment" {
+  description = "Whether this is a managed deployment, for new managed deployments, a default policy is added for access to the administrator role to assist with first time setup. You should not set this to true if you manage your own BYOC deployment."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -483,3 +483,9 @@ variable "control_plane_target_group_arns" {
   default     = []
   type        = list(string)
 }
+
+variable "managed_deployment" {
+  description = "Whether this is a managed deployment, for new managed deployments, a default policy is added for access to the administrator role to assist with first time setup. You should not set this to true if you manage your own BYOC deployment."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds additional environment variables to the control plane and access handler, these previously has default values.