### PR TITLE
Fix the default value for the 'rds_instance_identifier_suffix' variable

### DIFF
--- a/.changeset/lovely-forks-work.md
+++ b/.changeset/lovely-forks-work.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fixes the default value for the 'rds_instance_identifier_suffix' variable, to fix an error: 'The expression result is null' when applying the Terraform stack.

--- a/variables.tf
+++ b/variables.tf
@@ -463,7 +463,7 @@ variable "rds_snapshot_identifier" {
 variable "rds_instance_identifier_suffix" {
   description = "(Optional) adds a suffix to the database identifier"
   type        = string
-  default     = null
+  default     = ""
 
 }
 variable "web_target_group_arns" {


### PR DESCRIPTION
Fixes the default value for the 'rds_instance_identifier_suffix' variable, to fix an error: 'The expression result is null' when applying the Terraform stack.

