### PR TITLE
Fix the 'cloudwatch_alarm_topics' topic to correctly include database_alerts

### DIFF
--- a/.changeset/witty-brooms-warn.md
+++ b/.changeset/witty-brooms-warn.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+For BYOC customers: fix an issue with the 'cloudwatch_alarm_topics' output which caused the database alarms to not be correctly available.

--- a/modules/alerts/outputs.tf
+++ b/modules/alerts/outputs.tf
@@ -29,7 +29,7 @@ output "cloudwatch_alarm_topics" {
       sns_topic_arn = aws_sns_topic.load_balancer_alerts.arn
     }
 
-    load_balancer_alerts = {
+    database_alerts = {
       emitted_when  = "Issues with the database"
       sns_topic_arn = aws_sns_topic.database_alerts.arn
     }


### PR DESCRIPTION
The key was incorrectly set to 'load_balancer_alerts'.
