### PR TITLE
Add `iam_role_permission_boundary` variable

### DIFF
--- a/.changeset/stupid-tools-return.md
+++ b/.changeset/stupid-tools-return.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": minor
+---
+
+For BYOC customers: adds a new 'iam_role_permission_boundary' which can be used to apply a permission boundary to all IAM roles provisioned by the Terraform module.

--- a/modules/access/main.tf
+++ b/modules/access/main.tf
@@ -50,8 +50,9 @@ resource "aws_cloudwatch_log_group" "access_handler_log_group" {
 
 
 resource "aws_iam_role" "access_handler_ecs_execution_role" {
-  name        = "${var.namespace}-${var.stage}-access-handler-er"
-  description = "The execution role used by ECS to run the Access Handler task."
+  name                 = "${var.namespace}-${var.stage}-access-handler-er"
+  description          = "The execution role used by ECS to run the Access Handler task."
+  permissions_boundary = var.iam_role_permission_boundary
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -116,8 +117,9 @@ resource "aws_iam_role_policy_attachment" "access_handler_ecs_execution_role_pol
 
 # TASK ROLE
 resource "aws_iam_role" "access_handler_ecs_task_role" {
-  name        = "${var.namespace}-${var.stage}-access-handler-ecs-tr"
-  description = "The task role assumed by the Access Handler task."
+  name                 = "${var.namespace}-${var.stage}-access-handler-ecs-tr"
+  description          = "The task role assumed by the Access Handler task."
+  permissions_boundary = var.iam_role_permission_boundary
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/modules/access/variables.tf
+++ b/modules/access/variables.tf
@@ -235,3 +235,10 @@ variable "builtin_provisioner_url" {
   description = "The URL of the builtin provisioner."
   type        = string
 }
+
+variable "iam_role_permission_boundary" {
+  description = "If provided, attaches a Permission Boundary to all IAM roles in the module."
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/modules/aws-idc-integration/iam-roles/main.tf
+++ b/modules/aws-idc-integration/iam-roles/main.tf
@@ -27,9 +27,10 @@ data "aws_iam_policy_document" "assume_roles_policy" {
   }
 }
 resource "aws_iam_role" "read_role" {
-  name               = "${var.namespace}-${var.stage}-idc-reader-role"
-  description        = "A role used by Common Fate to read AWS IDC resources"
-  assume_role_policy = data.aws_iam_policy_document.assume_roles_policy.json
+  name                 = "${var.namespace}-${var.stage}-idc-reader-role"
+  description          = "A role used by Common Fate to read AWS IDC resources"
+  permissions_boundary = var.iam_role_permission_boundary
+  assume_role_policy   = data.aws_iam_policy_document.assume_roles_policy.json
   tags = {
     "common-fate-aws-integration-read-role" = "true"
   }
@@ -79,9 +80,10 @@ resource "aws_iam_role_policy_attachment" "read_role_policy_attach" {
 }
 
 resource "aws_iam_role" "provision_role" {
-  name               = "${var.namespace}-${var.stage}-idc-provisioner-role"
-  description        = "A role used by Common Fate to provision access in AWS IDC"
-  assume_role_policy = data.aws_iam_policy_document.assume_roles_policy.json
+  name                 = "${var.namespace}-${var.stage}-idc-provisioner-role"
+  description          = "A role used by Common Fate to provision access in AWS IDC"
+  permissions_boundary = var.iam_role_permission_boundary
+  assume_role_policy   = data.aws_iam_policy_document.assume_roles_policy.json
   tags = {
     "common-fate-aws-integration-provision-role" = "true"
   }

--- a/modules/aws-idc-integration/iam-roles/variables.tf
+++ b/modules/aws-idc-integration/iam-roles/variables.tf
@@ -13,15 +13,15 @@ variable "stage" {
 // This has been deprecated in favour of using tag based assume role policies
 variable "common_fate_aws_reader_role_arn" {
   description = "Deprecated: Use common_fate_aws_account_id instead"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 // This has been deprecated in favour of using tag based assume role policies
 variable "common_fate_aws_provisioner_role_arn" {
   description = "Deprecated: Use common_fate_aws_account_id instead"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "permit_management_account_assignments" {
@@ -51,4 +51,11 @@ variable "assume_role_external_id" {
   description = "The external id to be used for the IAM policy trust relation"
   type        = string
   default     = ""
+}
+
+variable "iam_role_permission_boundary" {
+  description = "If provided, attaches a Permission Boundary to all IAM roles in the module."
+  type        = string
+  nullable    = true
+  default     = null
 }

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -90,7 +90,8 @@ resource "aws_cloudwatch_log_group" "worker_log_group" {
 
 # EXECUTION ROLE
 resource "aws_iam_role" "control_plane_ecs_execution_role" {
-  name = "${var.namespace}-${var.stage}-control-plane-ecs-er"
+  name                 = "${var.namespace}-${var.stage}-control-plane-ecs-er"
+  permissions_boundary = var.iam_role_permission_boundary
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -177,7 +178,8 @@ resource "aws_iam_role_policy_attachment" "control_plane_ecs_task_parameter_stor
 
 # TASK ROLE
 resource "aws_iam_role" "control_plane_ecs_task_role" {
-  name = "${var.namespace}-${var.stage}-control-plane-ecs-tr"
+  name                 = "${var.namespace}-${var.stage}-control-plane-ecs-tr"
+  permissions_boundary = var.iam_role_permission_boundary
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/modules/controlplane/variables.tf
+++ b/modules/controlplane/variables.tf
@@ -416,3 +416,10 @@ variable "compare_entitlements_enabled" {
   type        = bool
   default     = true
 }
+
+variable "iam_role_permission_boundary" {
+  description = "If provided, attaches a Permission Boundary to all IAM roles in the module."
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/modules/provisioner/main.tf
+++ b/modules/provisioner/main.tf
@@ -49,8 +49,9 @@ resource "aws_cloudwatch_log_group" "provisioner_log_group" {
 
 
 resource "aws_iam_role" "provisioner_ecs_execution_role" {
-  name        = "${local.name_prefix}-provisioner-er"
-  description = "The execution role used by ECS to run the Provisioner task."
+  name                 = "${local.name_prefix}-provisioner-er"
+  permissions_boundary = var.iam_role_permission_boundary
+  description          = "The execution role used by ECS to run the Provisioner task."
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -82,8 +83,9 @@ resource "aws_iam_role_policy_attachment" "provisioner_ecs_execution_role_policy
 # The task role will be configured to have assuem role permissions on specific roles
 # these roles are configured in the terraform config provider along with the webhooks
 resource "aws_iam_role" "provisioner_ecs_task_role" {
-  name        = "${local.name_prefix}-provisioner-ecs-tr"
-  description = "The task role assumed by the Provisioner task."
+  name                 = "${local.name_prefix}-provisioner-ecs-tr"
+  permissions_boundary = var.iam_role_permission_boundary
+  description          = "The task role assumed by the Provisioner task."
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/modules/provisioner/variables.tf
+++ b/modules/provisioner/variables.tf
@@ -182,3 +182,10 @@ variable "factory_monitoring" {
   type        = bool
   default     = true
 }
+
+variable "iam_role_permission_boundary" {
+  description = "If provided, attaches a Permission Boundary to all IAM roles in the module."
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -29,7 +29,8 @@ resource "aws_security_group" "ecs_web_sg_v2" {
 }
 
 resource "aws_iam_role" "web_ecs_execution_role" {
-  name = "${var.namespace}-${var.stage}-web-ecs-er"
+  name                 = "${var.namespace}-${var.stage}-web-ecs-er"
+  permissions_boundary = var.iam_role_permission_boundary
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -161,3 +161,10 @@ variable "web_target_group_arns" {
   description = "Additional target groups to attach the service to."
   default     = []
 }
+
+variable "iam_role_permission_boundary" {
+  description = "If provided, attaches a Permission Boundary to all IAM roles in the module."
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -496,3 +496,10 @@ variable "compare_entitlements_enabled" {
   type        = bool
   default     = true
 }
+
+variable "iam_role_permission_boundary" {
+  description = "If provided, attaches a Permission Boundary to all IAM roles in the module."
+  type        = string
+  nullable    = true
+  default     = null
+}


### PR DESCRIPTION
Adds support for a permission boundary applied to all roles in the Terraform stack.

Guide for code review: confirm that the permissions boundary variable is applied to all resource "aws_iam_role" resources. I left it off the `general-purpose` submodule as that module is unused (I've raised a separate PR in #355 to delete the module entirely).