### PR TITLE
Add ssm:DeleteParameter permissions for managing integration secrets

### DIFF
--- a/.changeset/shiny-rules-deny.md
+++ b/.changeset/shiny-rules-deny.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Adds ssm:DeleteParameter permission to the control plane for managing integration secrets

--- a/modules/controlplane/main.tf
+++ b/modules/controlplane/main.tf
@@ -204,17 +204,17 @@ resource "aws_iam_role" "control_plane_ecs_task_role" {
 
 resource "aws_iam_policy" "parameter_store_secrets_write_access" {
   name        = "${var.namespace}-${var.stage}-control-plane-ps-write"
-  description = "Allows writing secrets to SSM Parameter Store"
+  description = "Allows writing and deleting secrets under the /<namespace>/<stage>/ path in SSM Parameter Store"
 
   policy = jsonencode({
     Version = "2012-10-17",
-    // include only the secrets that are configured
     Statement = [
       {
         Effect = "Allow"
         Action = [
           "ssm:PutParameter",
-          "ssm:AddTagsToResource"
+          "ssm:AddTagsToResource",
+          "ssm:DeleteParameter",
         ]
         Resource = [
           "arn:${var.aws_partition}:ssm:${var.aws_region}:${var.aws_account_id}:parameter/${var.namespace}/${var.stage}/*",


### PR DESCRIPTION
This parameter is required for the delete secret feature in the console and was omitted during the initial release of the feature