### PR TITLE
Add Terraform variable for IDP-initiated SAML SSO

### DIFF
--- a/.changeset/metal-drinks-occur.md
+++ b/.changeset/metal-drinks-occur.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+Fix an issue where enabling IDP-initiated SAML SSO login would cause Terraform drift. You can now set the `saml_allow_idp_initiated_sign_in` variable to `true` to avoid configuration drift.

--- a/main.tf
+++ b/main.tf
@@ -148,6 +148,7 @@ module "cognito" {
   saml_metadata_is_file               = var.saml_metadata_is_file
   saml_metadata_source                = var.saml_metadata_source
   saml_provider_name                  = var.saml_provider_name
+  saml_allow_idp_initiated_sign_in    = var.saml_allow_idp_initiated_sign_in
   web_access_token_validity_duration  = var.web_access_token_validity_duration
   web_access_token_validity_units     = var.web_access_token_validity_units
   web_refresh_token_validity_duration = var.web_refresh_token_validity_duration
@@ -156,8 +157,7 @@ module "cognito" {
   cli_access_token_validity_units     = var.cli_access_token_validity_units
   cli_refresh_token_validity_duration = var.cli_refresh_token_validity_duration
   cli_refresh_token_validity_units    = var.cli_refresh_token_validity_units
-
-  invite_user_emails = var.administrator_emails
+  invite_user_emails                  = var.administrator_emails
 }
 
 
@@ -392,4 +392,3 @@ module "authz-legacy" {
   namespace = var.namespace
   stage     = var.stage
 }
-

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -39,8 +39,16 @@ resource "aws_cognito_identity_provider" "saml_idp" {
 
   provider_details = var.saml_metadata_is_file ? {
     MetadataFile = file(var.saml_metadata_source)
+    IDPInit      = var.saml_allow_idp_initiated_sign_in
+    # EncryptedResponses is set to false to mitigate Terraform drifting the configuration by trying to set it to `null`.
+    # In future we may allow this to be configured by users.
+    EncryptedResponses = false
     } : {
     MetadataURL = var.saml_metadata_source
+    IDPInit     = var.saml_allow_idp_initiated_sign_in
+    # EncryptedResponses is set to false to mitigate Terraform drifting the configuration by trying to set it to `null`.
+    # In future we may allow this to be configured by users.
+    EncryptedResponses = false
   }
   lifecycle {
     ignore_changes = [

--- a/modules/cognito/variables.tf
+++ b/modules/cognito/variables.tf
@@ -99,3 +99,9 @@ variable "invite_user_emails" {
   default     = []
   type        = list(string)
 }
+
+variable "saml_allow_idp_initiated_sign_in" {
+  description = "If true, allows IDP-initiated sign-in in addition to SP-initiated sign-in."
+  default     = false
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -504,4 +504,8 @@ variable "iam_role_permission_boundary" {
   default     = null
 }
 
-
+variable "saml_allow_idp_initiated_sign_in" {
+  description = "If true, allows IDP-initiated sign-in in addition to SP-initiated sign-in."
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
Fixes an issue where enabling IDP-initiated SAML SSO login would cause Terraform drift. You can now set the `saml_allow_idp_initiated_sign_in` variable to `true` to avoid configuration drift.

