### PR TITLE
Vignesh/cf 3811 type in the access handler ecs task memory argument for the

### DIFF
--- a/.changeset/lazy-spoons-remember.md
+++ b/.changeset/lazy-spoons-remember.md
@@ -1,0 +1,5 @@
+---
+"@common-fate/terraform-aws-common-fate-deployment": patch
+---
+
+fixed a typo in `access_handler_ecs_task_memory`

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "control_plane_db" {
   apply_immediately              = var.rds_apply_immediately
   snapshot_identifier            = var.rds_snapshot_identifier
   rds_instance_identifier_suffix = var.rds_instance_identifier_suffix
-  rds_instance_type = var.rds_instance_type
+  rds_instance_type              = var.rds_instance_type
 }
 
 
@@ -346,7 +346,7 @@ module "access_handler" {
   factory_base_url                          = var.factory_base_url
   factory_oidc_issuer                       = var.factory_oidc_issuer
   ecs_task_cpu                              = var.access_handler_ecs_task_cpu
-  ecs_task_memory                           = var.access_hander_ecs_task_memory
+  ecs_task_memory                           = var.access_handler_ecs_task_memory
   access_target_group_arns                  = var.access_target_group_arns
   builtin_provisioner_url                   = module.provisioner.provisioner_url
   iam_role_permission_boundary              = var.iam_role_permission_boundary

--- a/variables.tf
+++ b/variables.tf
@@ -430,7 +430,7 @@ variable "worker_ecs_task_cpu" {
   default     = "512"
 }
 
-variable "access_hander_ecs_task_memory" {
+variable "access_handler_ecs_task_memory" {
   description = "The amount of memory to allocate for the ECS task. Specified in MiB."
   type        = string
   default     = "1024"


### PR DESCRIPTION
Fixed a typo for `access_handler_ecs_task_memory`